### PR TITLE
fix issue #99 : 改用更可靠的方式识别操作系统

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,15 @@ last_conversation.md
 全书复刻/**/tex/layout_comparison_report.json
 全书复刻/**/tex/排版一致性比较报告.md
 全书复刻/**/tex/*.pdf
+
+# macOS related
+.DS_Store
+.localized
+__MACOSX/
+.AppleDouble
+.LSOverride
+Icon[]
+
+# test related
+test/regression_test/*/current
+test/regression_test/*/diff

--- a/test/unit_test/fonts/luatex-cn-font-autodetect-test.lua
+++ b/test/unit_test/fonts/luatex-cn-font-autodetect-test.lua
@@ -6,7 +6,7 @@ local test_utils = require('test.test_utils')
 local fontdetect = require('tex.fonts.luatex-cn-font-autodetect')
 
 -- Save originals
-local org_os_type = os.type
+local org_os_name = os.name
 local org_pkg_config = package.config
 local org_io_popen = io.popen
 
@@ -14,33 +14,34 @@ local org_io_popen = io.popen
 -- detect_os
 -- ============================================================================
 
-test_utils.run_test("detect_os: Windows via os.type", function()
-    os.type = "windows"
+test_utils.run_test("detect_os: Windows via os.name", function()
+    os.name = "windows"
     test_utils.assert_eq(fontdetect.detect_os(), "windows")
-    os.type = org_os_type
+    os.name = org_os_name
 end)
 
-test_utils.run_test("detect_os: Windows via package.config", function()
-    os.type = "unix"
-    package.config = "\\\n;\n?\n!\n-"
-    test_utils.assert_eq(fontdetect.detect_os(), "windows")
-    os.type = org_os_type
-    package.config = org_pkg_config
-end)
-
-test_utils.run_test("detect_os: Mac via uname", function()
-    os.type = "unix"
-    package.config = "/\n;\n?\n!\n-"
-    io.popen = function()
-        return {
-            read = function() return "Darwin" end,
-            close = function() end
-        }
-    end
+test_utils.run_test("detect_os: Mac via os.name", function()
+    os.name = "macosx"
     test_utils.assert_eq(fontdetect.detect_os(), "mac")
-    os.type = org_os_type
-    package.config = org_pkg_config
-    io.popen = org_io_popen
+    os.name = org_os_name
+end)
+
+test_utils.run_test("detect_os: linux via os.name", function()
+    os.name = "linux"
+    test_utils.assert_eq(fontdetect.detect_os(), "linux")
+    os.name = org_os_name
+end)
+
+test_utils.run_test("detect_os: unknown", function()
+    os.name = "0xdeadbeaf"
+    test_utils.assert_eq(fontdetect.detect_os(), "common")
+    os.name = org_os_name
+end)
+
+test_utils.run_test("detect_os: nil", function()
+    os.name = nil
+    test_utils.assert_eq(fontdetect.detect_os(), "common")
+    os.name = org_os_name
 end)
 
 -- ============================================================================

--- a/tex/fonts/luatex-cn-font-autodetect.lua
+++ b/tex/fonts/luatex-cn-font-autodetect.lua
@@ -126,27 +126,19 @@ fontdetect.schemes = {
     }
 }
 
+
+
 -- Detect operating system
 function fontdetect.detect_os()
-    local os_type = os.type or "unix"
+    -- see [https://texluacats.github.io/LuaTeX/globals/os/#osname] for details.
+    local os_name = os.name
 
-    -- Check if Windows
-    if os_type == "windows" or package.config:sub(1, 1) == '\\' then
-        return "windows"
-    end
-
-    -- Check if macOS (Darwin)
-    local handle = io.popen("uname -s 2>/dev/null")
-    if handle then
-        local result = handle:read("*a")
-        handle:close()
-        if result and result:match("Darwin") then
-            return "mac"
-        end
-    end
-
-    -- Assume Linux/Unix
-    return "linux"
+    if os_name == "windows" then return "windows" end
+    if os_name == "linux" then return "linux" end
+    if os_name == "macosx" then return "mac" end
+    
+    -- undetermined operating system
+    return "common"
 end
 
 -- Check if a single font name is available


### PR DESCRIPTION
luatex 提供了 `os.name` 这一全局变量指示当前所运行的操作系统。由此我们便可以跳过识别 `os.type` 的步骤同时避免需要使用 shell-escape 这一不安全的编译选项。