### PR TITLE
提高回归测试宽容度

### DIFF
--- a/scripts/compare_pdfs.py
+++ b/scripts/compare_pdfs.py
@@ -126,7 +126,7 @@ def compare_pdfs(
         for i in range(n_pages):
             page_num = i + 1
             diff_tmp = dir_diff / f"diff_{page_num:04d}.png"
-            diff_count = compare_images(pngs_a[i], pngs_b[i], diff_tmp)
+            diff_count, _ = compare_images(pngs_a[i], pngs_b[i], diff_tmp)
 
             if diff_count > threshold:
                 if first_diff_page is None:

--- a/scripts/image_compare.py
+++ b/scripts/image_compare.py
@@ -62,7 +62,7 @@ def pdf_to_pngs(pdf_file: Path, output_dir: Path, dpi: int = 300) -> list:
     return pngs
 
 
-def compare_images(baseline_png: Path, current_png: Path, diff_png: Path) -> int:
+def compare_images(baseline_png: Path, current_png: Path, diff_png: Path) -> tuple[int, int]:
     """Compare two PNG images and generate a composite diff image.
 
     Composite colouring:
@@ -79,7 +79,8 @@ def compare_images(baseline_png: Path, current_png: Path, diff_png: Path) -> int
         diff_png:     Path where the diff image will be saved.
 
     Returns:
-        Number of pixels that differ between the two images.
+        Number of pixels that differ between the two images, and
+        number pixels of image.
     """
     baseline_img = Image.open(baseline_png).convert("RGB")
     current_img = Image.open(current_png).convert("RGB")
@@ -121,4 +122,4 @@ def compare_images(baseline_png: Path, current_png: Path, diff_png: Path) -> int
         diff_img = Image.fromarray(result)
         diff_img.save(str(diff_png))
 
-    return diff_count
+    return diff_count, w * h

--- a/test/regression_test.py
+++ b/test/regression_test.py
@@ -20,6 +20,7 @@ import multiprocessing
 BASE_DIR = Path(__file__).parent.parent.resolve()
 REG_DIR = BASE_DIR / "test" / "regression_test"
 DIFF_THRESHOLD = 200
+DIFF_RATIO_THRESHOLD = 0.2
 
 # Test suites: each has its own tex/, baseline/, current/, diff/, pdf/ subdirectories
 SUITES = {
@@ -193,20 +194,25 @@ def process_file(tex_file, mode, pdf_dir, baseline_dir, current_dir, diff_dir):
             return False, f"Page count mismatch: current={len(current_pngs)}, baseline={len(baseline_pngs)}", log_list
 
         total_diff_pixels = 0
+        total_pixels = 0
         failing_pages = []
 
         for i, (b_png, c_png) in enumerate(zip(baseline_pngs, current_pngs)):
             diff_png = diff_dir / f"diff_{c_png.name}"
-            diff_count = compare_images_logged(b_png, c_png, diff_png, log_list)
+            diff_count, pixel_count = compare_images_logged(b_png, c_png, diff_png, log_list)
 
-            if diff_count > 0:
-                total_diff_pixels += diff_count
+            diff_ratio = 100 * diff_count / pixel_count
+            
+            total_pixels += pixel_count
+            total_diff_pixels += diff_count
+
+            if diff_count > DIFF_THRESHOLD and diff_ratio > DIFF_RATIO_THRESHOLD:
                 failing_pages.append(i + 1)
-                log_list.append(f"  Page {i+1} fails: {diff_count} pixels difference.")
-            elif diff_count == 0:
+                log_list.append(f"  Page {i+1} fails: {diff_count} ({diff_ratio:.4f}%) pixels difference.")
+            elif diff_png.exists():
                 if diff_png.exists(): diff_png.unlink()
-            else:
-                return False, f"Comparison error on page {i+1}", log_list
+        
+        total_diff_ratio = 100 * total_diff_pixels / total_pixels
 
         # Check JSON baseline if present
         json_ok = True
@@ -242,21 +248,23 @@ def process_file(tex_file, mode, pdf_dir, baseline_dir, current_dir, diff_dir):
             if pdf_file.exists():
                 pdf_file.unlink()
             return True, 0, log_list
-        elif total_diff_pixels < DIFF_THRESHOLD and json_ok:
-            log_list.append(f"WARNING: {tex_file.name} has minor differences ({total_diff_pixels} pixels), but they are below threshold ({DIFF_THRESHOLD}). Marking as PASSED.")
+        elif total_diff_pixels < DIFF_THRESHOLD or total_diff_ratio < DIFF_RATIO_THRESHOLD and json_ok:
+            log_list.append(f"WARNING: {tex_file.name} has minor differences [{total_diff_pixels} " \
+                            f"({total_diff_ratio:.4f}%) pixels], but they are below threshold " \
+                            f"({DIFF_THRESHOLD} or {DIFF_RATIO_THRESHOLD:.4f}%). Marking as PASSED.")
             for png in current_pngs:
                 png.unlink()
             for diff_png in diff_dir.glob(f"diff_{pdf_file.stem}-*.png"):
                 diff_png.unlink()
             if pdf_file.exists():
                 pdf_file.unlink()
-            return True, f"{total_diff_pixels} pixels (ignored)", log_list
+            return True, f"{total_diff_pixels} ({total_diff_ratio:.4f}%) pixels (ignored)", log_list
         else:
-            if not json_ok and total_diff_pixels == 0:
+            if not json_ok:
                 log_list.append(f"FAIL: {tex_file.name} JSON mismatch")
                 return False, f"JSON mismatch", log_list
             log_list.append(f"FAIL: {tex_file.name} differs on pages: {failing_pages}{json_info}")
-            return False, f"{total_diff_pixels} total pixels diff{json_info}", log_list
+            return False, f"{total_diff_pixels} ({total_diff_ratio:.4f}%) pixels, NOT IGNORABLE! {json_info}", log_list
 
 
 def resolve_files_in_suite(file_args, tex_dir):


### PR DESCRIPTION
不同操作系统、不同版本的软件（包括 TeX Live、Python 与 Poppler 等）对 PDF 的生成和栅格化的实现可能存在细微差异导致回归测试中经常出现排版元素发生个位数像素级别偏移的现象。如：
<img width="1115" height="1054" alt="image" src="https://github.com/user-attachments/assets/613c0aa2-5162-4d33-90ed-854d5a069633" />

该 Pull Request 提供了一种按发生变化的像素数占整页像素数的比例判定是否通过回归测试的方案。如果发生变化的像素数低于页面总像素数的 0.2% 则该页面也可以通过测试。

经测试这种方案大大降低了回归测试失败的误报率。在 macOS 上的失败率由几乎每个回归测试均失败降低到仅有个别回归测试失败。