### PR TITLE
test/ci: 可复现的测试字体方案、JSON 基线修复与 PR 自动测试

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -92,6 +92,9 @@ texlua test/unit_test/core/layout-grid-test.lua
 
 ### 回归测试（Regression Test）
 ```bash
+# 首次运行前：下载测试字体 TW-Kai 到 test/fonts/（不入库，不装系统字体）
+sh scripts/download_test_fonts.sh
+
 # 运行所有测试
 python3 test/regression_test.py check
 
@@ -101,6 +104,16 @@ python3 test/regression_test.py check test/regression_test/tex/shiji.tex
 # 更新基线（确认改动正确后）
 python3 test/regression_test.py save test/regression_test/tex/shiji.tex
 ```
+
+回归测试要点：
+
+- **测试字体**：测试 .tex 硬编码 TW-Kai 字体。`regression_test.py` 会自动把
+  `OSFONTDIR` 指向 `test/fonts/`，字体由 `scripts/download_test_fonts.sh`
+  下载（固定 mirror commit，可复现），无需安装到系统字体目录。
+- **JSON 基线**：layout JSON 与基线比较时忽略 `source_mtime` 等易变元数据
+  （git 检出会改变 mtime，与布局无关）。
+- **CI**：`.github/workflows/test.yml` 会对每个 PR 及 main/dev 的 push
+  先跑 unit test 再跑 regression test，本地通过后 CI 应当同样通过。
 
 ### 编译测试
 ```bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,84 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches: [main, dev]
+
+# 测试 workflow 只需要读代码；显式声明避免继承更宽的默认权限
+permissions:
+  contents: read
+
+concurrency:
+  group: test-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install TeX Live (texlua only)
+        uses: TeX-Live/setup-texlive-action@v3
+        with:
+          cache: true
+          packages: |
+            scheme-basic
+            luatex
+
+      - name: Run unit tests
+        run: texlua test/run_all.lua
+
+  regression-test:
+    runs-on: ubuntu-latest
+    needs: unit-test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install TeX Live
+        uses: TeX-Live/setup-texlive-action@v3
+        with:
+          cache: true
+          packages: |
+            scheme-basic
+            latex-bin
+            luatex
+            luaotfload
+            ctablestack
+            fontspec
+            geometry
+            graphics
+            enumitem
+            environ
+            eso-pic
+            l3kernel
+            l3packages
+            showframe
+            pgf
+            xcolor
+            ctex
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y poppler-utils python3-pil python3-numpy
+
+      - name: Cache test fonts
+        uses: actions/cache@v4
+        with:
+          path: test/fonts
+          key: test-fonts-${{ hashFiles('scripts/download_test_fonts.sh') }}
+
+      - name: Download test fonts
+        run: sh scripts/download_test_fonts.sh
+
+      - name: Link luatex-cn into TEXMFHOME
+        run: |
+          mkdir -p ~/texmf/tex/lualatex
+          ln -s "$GITHUB_WORKSPACE/tex" ~/texmf/tex/lualatex/luatex-cn
+
+      - name: Run regression tests
+        run: python3 test/regression_test.py check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,19 +47,23 @@ jobs:
             latex-bin
             luatex
             luaotfload
+            luatexbase
             ctablestack
             fontspec
+            iftex
             geometry
             graphics
             enumitem
             environ
+            trimspaces
             eso-pic
+            xkeyval
+            etoolbox
             l3kernel
             l3packages
             showframe
             pgf
             xcolor
-            ctex
 
       - name: Install system dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,6 @@ jobs:
             etoolbox
             l3kernel
             l3packages
-            showframe
             pgf
             xcolor
 
@@ -80,9 +79,16 @@ jobs:
         run: sh scripts/download_test_fonts.sh
 
       - name: Link luatex-cn into TEXMFHOME
+        # 显式设置 TEXMFHOME（kpathsea 读取该环境变量），确保 lualatex
+        # 能找到仓库里的 ltc-*.cls 与 luatex-cn 宏包
         run: |
-          mkdir -p ~/texmf/tex/lualatex
-          ln -s "$GITHUB_WORKSPACE/tex" ~/texmf/tex/lualatex/luatex-cn
+          mkdir -p "$GITHUB_WORKSPACE/ci-texmf/tex/lualatex"
+          ln -s "$GITHUB_WORKSPACE/tex" "$GITHUB_WORKSPACE/ci-texmf/tex/lualatex/luatex-cn"
+          echo "TEXMFHOME=$GITHUB_WORKSPACE/ci-texmf" >> "$GITHUB_ENV"
+          kpsewhich -var-value TEXMFHOME || true
+
+      - name: Verify class resolution
+        run: kpsewhich ltc-guji.cls
 
       - name: Run regression tests
         run: python3 test/regression_test.py check

--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ Icon[]
 # test related
 test/regression_test/*/current
 test/regression_test/*/diff
+
+# repo-local test fonts (downloaded by scripts/download_test_fonts.sh)
+test/fonts/

--- a/scripts/download_test_fonts.sh
+++ b/scripts/download_test_fonts.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# 下载回归测试所需的字体到 test/fonts/（该目录不入库）。
+# regression_test.py 会将 OSFONTDIR 指向 test/fonts，luaotfload 据此解析字体名。
+# 字体来源：全字庫 (CNS11643)，镜像仓库 free-fonts-npm/TW-CNS11643-Fonts，固定到 commit 以保证可复现。
+set -eu
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+FONTS_DIR="$REPO_ROOT/test/fonts"
+MIRROR="https://raw.githubusercontent.com/free-fonts-npm/TW-CNS11643-Fonts/de5bd2e37371798f996bac11ea8cf9d3a411749e/2026-05-05"
+
+mkdir -p "$FONTS_DIR"
+
+download() {
+    name=$1
+    url=$2
+    if [ -s "$FONTS_DIR/$name" ]; then
+        echo "已存在: $name"
+    else
+        echo "下载: $name"
+        curl -fL --retry 3 -o "$FONTS_DIR/$name.part" "$url"
+        mv "$FONTS_DIR/$name.part" "$FONTS_DIR/$name"
+    fi
+}
+
+download "TW-Kai-98_1.ttf" "$MIRROR/Fonts_Kai/TW-Kai-98_1.ttf"
+
+echo "完成。字体位于 $FONTS_DIR"

--- a/test/regression_test.py
+++ b/test/regression_test.py
@@ -19,6 +19,19 @@ import multiprocessing
 # Paths relative to the project root
 BASE_DIR = Path(__file__).parent.parent.resolve()
 REG_DIR = BASE_DIR / "test" / "regression_test"
+
+# 仓库内测试字体（TW-Kai 等），由 scripts/download_test_fonts.sh 下载。
+# 通过 OSFONTDIR 让 luaotfload 找到它们，无需安装到系统字体目录。
+FONTS_DIR = BASE_DIR / "test" / "fonts"
+_prev_osfontdir = os.environ.get("OSFONTDIR")
+os.environ["OSFONTDIR"] = (
+    f"{FONTS_DIR}{os.pathsep}{_prev_osfontdir}" if _prev_osfontdir else str(FONTS_DIR)
+)
+if not list(FONTS_DIR.glob("*.ttf")):
+    print(
+        f"WARNING: {FONTS_DIR} 中没有字体文件，编译可能因缺少 TW-Kai 失败。\n"
+        "请先运行: sh scripts/download_test_fonts.sh"
+    )
 DIFF_THRESHOLD = 200
 DIFF_RATIO_THRESHOLD = 0.2
 
@@ -39,6 +52,21 @@ def get_suite_dirs(suite_dir):
         suite_dir / "current",
         suite_dir / "diff",
     )
+
+
+# JSON 布局导出中的易变元数据键，比较基线时忽略（例如 source_mtime 在
+# git 检出后必然变化，与布局本身无关）。
+VOLATILE_JSON_KEYS = {"source_mtime"}
+
+
+def strip_volatile_json(data):
+    """Recursively drop volatile metadata keys before baseline comparison."""
+    if isinstance(data, dict):
+        return {k: strip_volatile_json(v) for k, v in data.items()
+                if k not in VOLATILE_JSON_KEYS}
+    if isinstance(data, list):
+        return [strip_volatile_json(v) for v in data]
+    return data
 
 
 def run_command(cmd, cwd=None, capture=True, log_list=None):
@@ -143,7 +171,7 @@ def process_file(tex_file, mode, pdf_dir, baseline_dir, current_dir, diff_dir):
                         new_data = json.load(f)
                     with open(baseline_json, 'r', encoding='utf-8') as f:
                         old_data = json.load(f)
-                    if new_data == old_data:
+                    if strip_volatile_json(new_data) == strip_volatile_json(old_data):
                         log_list.append(f"JSON baseline unchanged for {tex_file.name}")
                     else:
                         shutil.copy2(str(json_file), str(baseline_json))
@@ -224,7 +252,7 @@ def process_file(tex_file, mode, pdf_dir, baseline_dir, current_dir, diff_dir):
                     current_data = json.load(f)
                 with open(baseline_json, 'r', encoding='utf-8') as f:
                     baseline_data = json.load(f)
-                if current_data == baseline_data:
+                if strip_volatile_json(current_data) == strip_volatile_json(baseline_data):
                     log_list.append(f"JSON matches baseline for {tex_file.name}")
                 else:
                     json_ok = False

--- a/test/regression_test.py
+++ b/test/regression_test.py
@@ -99,6 +99,14 @@ def compile_tex(tex_file, pdf_dir, log_list):
 
         if res.returncode != 0:
             log_list.append(f"ERROR: Compilation failed for {ex_name}")
+            # 输出 lualatex 日志尾部，方便在 CI 上直接定位错误
+            output = res.stdout or ""
+            if res.stderr:
+                output += "\n" + res.stderr
+            tail = output.strip().splitlines()[-40:]
+            log_list.append(f"--- lualatex output tail for {ex_name} ---")
+            log_list.extend(tail)
+            log_list.append("--- end of output ---")
             return False
 
     return pdf_dir / pdf_name


### PR DESCRIPTION
## 改动内容

### 1. 测试字体 TW-Kai 的可复现提供方式 (`a70bb53`)
- 新增 `scripts/download_test_fonts.sh`：从固定 commit 的镜像仓库（free-fonts-npm/TW-CNS11643-Fonts）下载 `TW-Kai-98_1.ttf` 到 `test/fonts/`（已 gitignore），无需安装到系统字体目录
- `test/regression_test.py` 自动将 `OSFONTDIR` 指向 `test/fonts/`，luaotfload 找不到字体名时会自动重扫；缺字体时给出运行下载脚本的提示
- 本地与 CI 使用完全相同的字体来源，消除跨机器差异

### 2. 修复 JSON 基线比较的误报 (`a70bb53`)
- layout JSON 中的 `source_mtime` 是源文件修改时间，git 检出后必然变化，导致 `guji.tex` 在全新 clone 上必报 JSON mismatch
- 比较基线时忽略此类易变元数据键（`VOLATILE_JSON_KEYS`），save 和 check 两条路径都已处理

### 3. 对每个 PR 自动运行测试 (`d16f150`)
- 新增 `.github/workflows/test.yml`：`pull_request` 及 push 到 main/dev 时触发
- 流程：unit test（`texlua test/run_all.lua`）通过后再跑 regression test（TeX Live 按需装包并缓存 + poppler-utils + 字体 actions/cache）
- 安全性：使用 `pull_request` 触发器（fork PR 无 secrets、token 只读），顶层显式 `permissions: contents: read`；`concurrency` 自动取消同一分支的过时运行

### 4. 文档 (`047556c`)
- `.claude/CLAUDE.md` 回归测试一节补充：字体下载步骤、OSFONTDIR 机制、JSON 易变键规则、CI 说明

## 测试
- `texlua test/run_all.lua`：29/29 通过
- `python3 test/regression_test.py check`（basic 套件）：18/19 通过；仅剩的 3 个失败（decorate/gongche/textbox）为既有的跨平台字体渲染差异（未指定字体的用例，diff 为全页字形亚像素重影，在未改动的 main 上逐像素复现相同结果），与本 PR 无关