### PR TITLE
ci: 修复 main 上回归测试失败（补装 fandol 字体 + 预热字体数据库）

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,6 +78,12 @@ jobs:
       - name: Download test fonts
         run: sh scripts/download_test_fonts.sh
 
+      - name: Warm luaotfload font database
+        # regression_test.py 并行编译多个文件；若名字数据库尚未包含
+        # TW-Kai，所有 lualatex 进程会同时触发重扫并发写同一数据库，
+        # 部分进程读到残缺结果导致 fontspec 随机失败。先串行建好。
+        run: OSFONTDIR="$GITHUB_WORKSPACE/test/fonts" luaotfload-tool --update --force
+
       - name: Link luatex-cn into TEXMFHOME
         # 显式设置 TEXMFHOME（kpathsea 读取该环境变量），确保 lualatex
         # 能找到仓库里的 ltc-*.cls 与 luatex-cn 宏包

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,7 @@ jobs:
             l3packages
             pgf
             xcolor
+            fandol
 
       - name: Install system dependencies
         run: |


### PR DESCRIPTION
## 问题

PR #106 在分支上 CI 全绿，合并到 main 后 (`048d855`) regression workflow 失败（jiazhu 编译失败、decorate 页数 5≠4、gongche/textbox 像素差异）。两个 commit 的文件树完全相同，差异在运行环境。

## 根因（两次冷运行失败结果逐字节一致 → 确定性问题，非竞争）

**缺 fandol 字体。** Linux 上 `luatex-cn-font-autodetect` 把默认 main/sans/kai/fangsong 族解析到 Fandol 字体，回归基线也是按 Fandol 渲染的。#106 中把 `ctex` 从装包列表删掉时，把它传递依赖的 `fandol` 也一并丢了：

- 分支上唯一一次绿色运行，是因为 actions cache 按 restore-keys 复用了此前两轮（还装着 ctex/fandol）的 TeX Live 缓存
- push 到 main 的运行读不到 PR 分支缓存（GitHub cache 隔离），全新安装里没有 fandol：
  - `jiazhu.tex`：夹注默认楷体族找不到 FandolKai → fontspec 报错 → 编译失败
  - `decorate`/`gongche`/`textbox`（未显式指定字体）：回退到其他字体 → 页数（5≠4）与像素差异

## 修复

1. 装包列表补上 `fandol`（本 PR 第 2 个 commit，主修复）
2. 下载测试字体后串行执行一次 `luaotfload-tool --update --force` 预热名字数据库，避免并行编译时并发重建（第 1 个 commit，防御性加固）

包列表变化会生成新的 cache key，本 PR 的 CI 即为全新安装环境下的验证。