### PR TITLE
fix(textflow): 夹注列尾溢出与空列叠印两处修复（附单元测试）

### DIFF
--- a/test/run_all.lua
+++ b/test/run_all.lua
@@ -25,6 +25,7 @@ local tests = {
     "test/unit_test/core/flatten-nodes-test.lua",
 
     -- Core layer (complex modules, smoke tests)
+    "test/unit_test/core/textflow-test.lua",
     "test/unit_test/core/layout-grid-test.lua",
     "test/unit_test/core/layout-grid-band-test.lua",
     "test/unit_test/core/render-page-test.lua",

--- a/test/unit_test/core/textflow-test.lua
+++ b/test/unit_test/core/textflow-test.lua
@@ -1,0 +1,236 @@
+-- Unit tests for core.luatex-cn-core-textflow (white-box via _internal)
+-- Covers the column-wrap guards around place_textflow_segment:
+--   1. Wrap before placing when the column has no room for the first node
+--      (glyph would protrude beyond the column bottom border).
+--   2. Clear just_wrapped_column once textflow content is placed, and the
+--      matching smart-break empty-column guard in layout-grid.
+local test_utils = require("test.test_utils")
+
+-- Mock hooks module (required by layout-grid)
+_G.core = _G.core or {}
+_G.core.hooks = _G.core.hooks or {}
+_G.core.hooks.is_reserved_column = function(col, interval)
+    return col % (interval + 1) == interval
+end
+package.loaded['core.luatex-cn-hooks'] = {
+    is_reserved_column = _G.core.hooks.is_reserved_column,
+    get_plugins = function() return {} end,
+}
+
+local textflow = require("core.luatex-cn-core-textflow")
+local layout_grid = require("core.luatex-cn-layout-grid")
+local constants = require("core.luatex-cn-constants")
+local D = node.direct
+
+local GH = 655360  -- 10pt grid height
+
+-- Helper: build a textflow glyph node
+local function make_tf_glyph(char)
+    local g = D.new(constants.GLYPH)
+    D.setfield(g, "char", char or 0x4E00)
+    D.set_attribute(g, constants.ATTR_JIAZHU, 1)
+    return g
+end
+
+-- Helper: minimal ctx/params/callbacks for place_textflow_segment
+local function make_env(overrides)
+    local line_limit = 20
+    local ctx = {
+        cur_row = 0,
+        cur_y_sp = 0,
+        cur_col = 0,
+        cur_page = 0,
+        cur_band = 0,
+        p_cols = 10,
+        shift_x = 0,
+        shift_y = 0,
+        half_thickness = 0,
+        col_height_sp = line_limit * GH,
+        auto_column_wrap = true,
+        just_wrapped_column = false,
+        params = { grid_width = GH },
+    }
+    local params = {
+        grid_height = GH,
+        grid_width = GH,
+        effective_limit = line_limit,
+        line_limit = line_limit,
+        r_indent = 0,
+        base_indent = 0,
+        first_indent = -1,
+        textflow_mode = 0,
+        block_id = nil,
+    }
+    if overrides then
+        for k, v in pairs(overrides) do ctx[k] = v end
+    end
+    local wrap_count = 0
+    local callbacks = {
+        wrap = function()
+            wrap_count = wrap_count + 1
+            ctx.cur_col = ctx.cur_col + 1
+            ctx.cur_row = 0
+            ctx.cur_y_sp = 0
+        end,
+        get_indent = function() return 0 end,
+    }
+    return ctx, params, callbacks, function() return wrap_count end
+end
+
+-- ============================================================================
+-- _internal exports
+-- ============================================================================
+
+test_utils.run_test("textflow: _internal exported", function()
+    test_utils.assert_type(textflow._internal, "table")
+    test_utils.assert_type(textflow._internal.place_textflow_segment, "function")
+end)
+
+test_utils.run_test("get_node_h: falls back to default grid height", function()
+    test_utils.assert_eq(textflow._internal.get_node_h(nil, 1, GH), GH)
+    test_utils.assert_eq(textflow._internal.get_node_h({ [1] = 2 * GH }, 1, GH), 2 * GH)
+    test_utils.assert_eq(textflow._internal.get_node_h({ [1] = 2 * GH }, 2, GH), GH)
+end)
+
+-- ============================================================================
+-- Fix 1: wrap before placing when column has no room for the first node
+-- ============================================================================
+
+test_utils.run_test("place: full column wraps before placing first node", function()
+    local ctx, params, callbacks, wraps = make_env({
+        cur_row = 20,             -- column completely full
+        cur_y_sp = 20 * GH,
+    })
+    local layout_map = {}
+    local g = make_tf_glyph()
+    textflow._internal.place_textflow_segment(ctx, { g }, layout_map, params, callbacks, nil)
+
+    test_utils.assert_eq(wraps(), 1)  -- wrapped once before placing
+    local entry = layout_map[g]
+    test_utils.assert_type(entry, "table")
+    test_utils.assert_eq(entry.col, 1)   -- placed in the NEXT column
+    test_utils.assert_eq(entry.y_sp, 0)  -- at the top, not beyond the border
+end)
+
+test_utils.run_test("place: column with room does not wrap", function()
+    local ctx, params, callbacks, wraps = make_env({
+        cur_row = 5,
+        cur_y_sp = 5 * GH,
+    })
+    local layout_map = {}
+    local g = make_tf_glyph()
+    textflow._internal.place_textflow_segment(ctx, { g }, layout_map, params, callbacks, nil)
+
+    test_utils.assert_eq(wraps(), 0)
+    local entry = layout_map[g]
+    test_utils.assert_eq(entry.col, 0)
+    test_utils.assert_eq(entry.y_sp, 5 * GH)
+end)
+
+test_utils.run_test("place: no wrap guard when auto_column_wrap disabled", function()
+    local ctx, params, callbacks, wraps = make_env({
+        cur_row = 20,
+        cur_y_sp = 20 * GH,
+        auto_column_wrap = false,  -- digital mode: never auto-wrap
+    })
+    local layout_map = {}
+    local g = make_tf_glyph()
+    textflow._internal.place_textflow_segment(ctx, { g }, layout_map, params, callbacks, nil)
+
+    test_utils.assert_eq(wraps(), 0)
+    test_utils.assert_eq(layout_map[g].col, 0)
+end)
+
+-- ============================================================================
+-- Fix 2a: just_wrapped_column cleared when textflow places content
+-- ============================================================================
+
+test_utils.run_test("place: clears just_wrapped_column after placing", function()
+    local ctx, params, callbacks = make_env({
+        just_wrapped_column = true,
+    })
+    local layout_map = {}
+    textflow._internal.place_textflow_segment(ctx, { make_tf_glyph() }, layout_map, params, callbacks, nil)
+    test_utils.assert_eq(ctx.just_wrapped_column, false)
+end)
+
+test_utils.run_test("place: empty node list keeps just_wrapped_column", function()
+    local ctx, params, callbacks = make_env({
+        just_wrapped_column = true,
+    })
+    textflow._internal.place_textflow_segment(ctx, {}, {}, params, callbacks, nil)
+    test_utils.assert_eq(ctx.just_wrapped_column, true)
+end)
+
+-- ============================================================================
+-- Fix 2b: smart-break empty-column guard only discards pending state when
+-- the column is truly empty (just_wrapped_column still true)
+-- ============================================================================
+
+-- Helper: ctx for handle_penalty_node (mirrors layout-grid-test's make_penalty_ctx)
+local function make_penalty_ctx(overrides)
+    local ctx = {
+        cur_row = 0,
+        cur_col = 0,
+        cur_page = 1,
+        cur_y_sp = 0,
+        page_has_content = true,
+        cur_column_indent = 0,
+        occupancy = {},
+        just_wrapped_column = false,
+        col_widths_sp = {},
+        banxin_registry = {},
+        p_cols = 10,
+        n_bands = 1,
+        params = { banxin_on = false },
+    }
+    if overrides then
+        for k, v in pairs(overrides) do ctx[k] = v end
+    end
+    _G.page = _G.page or {}
+    _G.content = _G.content or {}
+    return ctx
+end
+
+-- Helper: smart-break penalty followed by a normal (non-textflow) glyph
+local function make_smart_break()
+    local p = D.new(constants.PENALTY)
+    D.setfield(p, "penalty", constants.PENALTY_SMART_BREAK)
+    local g = D.new(constants.GLYPH)
+    D.setfield(g, "char", 0x4E8C)
+    D.setlink(p, g)
+    return p
+end
+
+test_utils.run_test("smart-break: truly empty column discards pending state", function()
+    local ctx = make_penalty_ctx({
+        cur_row = 0,
+        textflow_pending_sub_col = 1,
+        textflow_pending_row_used = 2,
+        just_wrapped_column = true,  -- nothing placed since the wrap
+    })
+    layout_grid._internal.handle_penalty_node(make_smart_break(), ctx, GH, 0, 0, 10, function() end)
+
+    test_utils.assert_eq(ctx.textflow_pending_sub_col, nil)
+    test_utils.assert_eq(ctx.textflow_pending_row_used, nil)
+    test_utils.assert_eq(ctx.cur_row, 0)  -- no advance, no wrap
+    test_utils.assert_eq(ctx.cur_col, 0)
+end)
+
+test_utils.run_test("smart-break: column with textflow content flushes pending and wraps", function()
+    local ctx = make_penalty_ctx({
+        cur_row = 0,
+        textflow_pending_sub_col = 1,
+        textflow_pending_row_used = 2,
+        just_wrapped_column = false,  -- textflow HAS placed content here
+    })
+    layout_grid._internal.handle_penalty_node(make_smart_break(), ctx, GH, 0, 0, 10, function() end)
+
+    -- Pending rows flushed (cur_row advanced) then wrapped to next column
+    test_utils.assert_eq(ctx.textflow_pending_sub_col, nil)
+    test_utils.assert_eq(ctx.textflow_pending_row_used, nil)
+    test_utils.assert_eq(ctx.cur_col, 1)  -- wrap happened
+    test_utils.assert_eq(ctx.cur_row, 0)  -- new column starts at top
+end)
+
+print("\nAll textflow tests passed!")

--- a/tex/core/luatex-cn-core-textflow.lua
+++ b/tex/core/luatex-cn-core-textflow.lua
@@ -602,6 +602,27 @@ local function place_textflow_segment(ctx, nodes, layout_map, params, callbacks,
         start_sub_col = 2
     end
 
+    -- Guard: if the current column has no room for even one textflow node,
+    -- wrap to the next column first. Otherwise process_sequence force-places
+    -- the first node (its "at least one node per chunk" anti-loop guard) and
+    -- the glyph protrudes beyond the column bottom border.
+    if ctx.auto_column_wrap ~= false and start_sub_col ~= 2 then
+        local first_h = get_node_h(node_heights, 1, gh)
+        if available_height_sp < first_h then
+            callbacks.wrap()
+            local wrap_indent = callbacks.get_indent(params.block_id, orig_base_indent, orig_first_indent)
+            if ctx.cur_row < wrap_indent then
+                ctx.cur_row = wrap_indent
+                ctx.cur_y_sp = ctx.cur_row * (params.grid_height or 655360)
+            end
+            if textflow_gh then
+                available_height_sp = ctx.col_height_sp - ctx.cur_y_sp
+            else
+                available_height_sp = (params.effective_limit - ctx.cur_row) * gh
+            end
+        end
+    end
+
     local chunks, final_sub_col, final_row_used = textflow.process_sequence(
         nodes, available_height_sp, column_height_sp,
         params.textflow_mode, auto_balance, start_sub_col, nil,

--- a/tex/core/luatex-cn-core-textflow.lua
+++ b/tex/core/luatex-cn-core-textflow.lua
@@ -640,6 +640,15 @@ local function place_textflow_segment(ctx, nodes, layout_map, params, callbacks,
         end
     end
 
+    -- Textflow glyphs bypass col_buffer/flush, so the just_wrapped_column
+    -- flag (issue #54) is never cleared by them. Clear it here: content HAS
+    -- been placed in this column, otherwise the smart-break empty-column
+    -- guard later discards the pending rows and the next paragraph
+    -- overprints this column (big/small glyph overlap).
+    if #chunks > 0 and #chunks[1].nodes > 0 then
+        ctx.just_wrapped_column = false
+    end
+
     -- Place chunks into layout_map
     for i, chunk in ipairs(chunks) do
         if i > 1 then

--- a/tex/core/luatex-cn-core-textflow.lua
+++ b/tex/core/luatex-cn-core-textflow.lua
@@ -896,6 +896,12 @@ function textflow.place_nodes(ctx, start_node, layout_map, params, callbacks)
     return temp_t
 end
 
+-- Export internals for white-box unit testing
+textflow._internal = {
+    place_textflow_segment = place_textflow_segment,
+    get_node_h = get_node_h,
+}
+
 -- Register module
 package.loaded['core.luatex-cn-textflow'] = textflow
 

--- a/tex/core/luatex-cn-layout-grid.lua
+++ b/tex/core/luatex-cn-layout-grid.lua
@@ -1273,6 +1273,7 @@ local function handle_penalty_node(t, ctx, grid_height, indent, interval, p_cols
         handle_penalty_breaks(p_val, ctx, flush_fn, p_cols, interval, grid_height, indent, t)
     end
 end
+_internal.handle_penalty_node = handle_penalty_node
 
 --- Get grid width for free mode column tracking
 local function get_free_mode_grid_width(params)

--- a/tex/core/luatex-cn-layout-grid.lua
+++ b/tex/core/luatex-cn-layout-grid.lua
@@ -1250,7 +1250,9 @@ local function handle_penalty_node(t, ctx, grid_height, indent, interval, p_cols
                 -- clear stale textflow pending state without advancing cur_row.
                 -- Otherwise a normal flush would re-add pending rows from the
                 -- previous column and cause a double-wrap (empty column bug).
-                if ctx.cur_row == 0 and ctx.textflow_pending_row_used then
+                if ctx.cur_row == 0 and ctx.textflow_pending_row_used
+                    and ctx.just_wrapped_column then
+                    -- Truly-empty column right after a wrap: stale pending
                     ctx.textflow_pending_sub_col = nil
                     ctx.textflow_pending_row_used = nil
                 else


### PR DESCRIPTION
## 修复 1：列满时夹注首字戳出底框 (`610615a`)

**现象**：复刻民國南滙縣續志（10 列 × 21 字，正文与夹注 grid-height 均锁定 24.094pt）时，凡夹注恰好从满列处开始，其首字（如「見光緒志」的「見」）会画在列底边框之外。

**原因**：`process_sequence()` 有「每 chunk 至少放一个节点」的防死循环保护，当当前列剩余高度不足一个小字格时，该保护会强行把第一个节点放进当前列。

**修复**：`place_textflow_segment()` 调用 `process_sequence()` 之前检查当前列是否还装得下第一个节点；装不下则先 `callbacks.wrap()` 换列、重设缩进并重算可用高度（textflow grid-height 覆盖路径与行数路径都处理）。digital 模式（`auto_column_wrap=false`）及不平衡对左小列续排场景跳过此检查。

## 修复 2：整列夹注被误判为空列导致下段正文叠印 (`ce66645`)

**现象**：民國南滙縣續志第 13 叶，大字「十一年海潮衝壞…」叠印在小字「隨決不寬貸…特示」之上。

**原因**：夹注字形绕过 col_buffer/flush_buffer，issue #54 引入的 `just_wrapped_column` 标志永远不会被夹注清除。当一段完全由夹注构成且从列顶开始（cur_row==0、行数全部记在 pending 状态里），smart-break 的空列保护把该列当成空列，丢弃 pending 行且不换列，下一段正文从同一列开始叠印。

**修复**：
- `place_textflow_segment()`：chunk 节点实际放置后清除 `ctx.just_wrapped_column`
- smart-break 保护：仅当 `just_wrapped_column` 仍为 true（换列后真正的空列，即 issue #54 原场景）才丢弃 pending 状态；否则正常 flush pending 行，让后续换列判断看到真实的 cur_row

## 测试 (`d45c222`)

新增 `test/unit_test/core/textflow-test.lua`（9 个用例），通过 `_internal` 导出 `place_textflow_segment` / `handle_penalty_node` 做白盒测试，覆盖两个修复的正反场景。**每个用例都做过反向验证**：临时禁用对应修复时用例确实转红。

## 测试结果

- unit test：30/30 通过（新增 1 个测试文件）
- regression test：16/19 通过；3 个失败（decorate/gongche/textbox）为已知的 macOS 本地字体渲染差异，与本 PR 无关，CI（Linux + Fandol）应全绿