### PR TITLE
feat(fonts): canonical 字体清单 + SHA-256 校验下载，扩充字体文档

### DIFF
--- a/.claude/font-metrics.md
+++ b/.claude/font-metrics.md
@@ -1,3 +1,102 @@
+# 字体清单与 Metrics 特性总结
+
+> 项目所用字体的完整清单（版本、来源、覆盖范围、授权），可复现性约定，
+> 以及不同字体在 LuaTeX 中的 metrics 表现差异与应对策略。
+> 覆盖率数据由 fontTools 对字体 cmap 实测（2026-07-30，脚本见文末）。
+
+## 0. 字体清单（按用途）
+
+### 0.1 测试基准字体：TW-Kai（全字庫正楷體）
+
+回归测试的 .tex 硬编码此字体，是项目唯一"钉死"的字体。
+
+| 项目 | 值 |
+|------|-----|
+| 文件 | `TW-Kai-98_1.ttf`（37 MB，TTF，upem 1024） |
+| 版本 | Version **11503.01**（民國 115 年 3 月 = 2026-03） |
+| 字形数 | 39,208 glyphs / 39,203 码点 |
+| 覆盖 | CJK 基本区 20,923/20,992（99.7%）、Ext-A 6,591/6,592（100%）、CJK 标点 64/64；**不含 Ext-B**（在独立文件中） |
+| 官方来源 | 数位发展部 CNS11643 全字庫，data.gov.tw 数据集 5961 |
+| 获取途径 | `scripts/download_test_fonts.sh` → GitHub 镜像 `free-fonts-npm/TW-CNS11643-Fonts` **固定 commit `de5bd2e3`**（2026-05-05 批次） |
+| SHA-256 | `c206333edcc3c8c86ee547da4c78ad1c8f7ec2670a2b550a768532258f75806a` |
+| 授权 | **双授权二选一：政府資料開放授權條款 v1 或 SIL OFL 1.1**（官方声明，可按 OFL 1.1 使用/分发/嵌入） |
+
+同家族扩展文件（当前测试未用，古籍生僻字场景可按需引入，同一镜像 commit 下载）：
+
+| 文件 | 版本 | 码点数 | 覆盖 | SHA-256 |
+|------|------|--------|------|---------|
+| `TW-Kai-Ext-B-98_1.ttf`（46 MB） | 11505.01 | 49,568 | **Ext-B 42,711/42,720（100%）**、Ext-C 98.6%、Ext-D 87.1%、Ext-E 21.9% | `562d19fde56dfa52a3fed88a53154698e1d66e4b9c0a1faa9ba4ffa98e9d7a92` |
+| `TW-Kai-Plus-98_1.ttf`（25 MB） | 11505.01 | 25,079 | 全部在 **Plane 15 PUA**（U+F0000+，24,978 字）：CNS 有码、Unicode 未收的字 | `acd099424c70c2baf3fe8d7b31abbbc6a97af76ef210e94c07eb1eb84d1c62fb` |
+
+配套 TW-Sung（正宋體）三文件同批次同授权，镜像 `Fonts_Sung/` 目录。
+
+### 0.2 CI / Linux 自动检测字体：Fandol
+
+`font-autodetect.lua` 在 Linux 上的默认族；回归基线按它渲染。CI 通过
+TeX Live 包 `fandol` 安装（**版本随 CTAN 漂移，无法锁定**——TL 生态限制）。
+
+| 项目 | 值 |
+|------|-----|
+| 文件 | FandolSong/Hei/Kai/Fang-Regular.otf（OTF/CFF，upem 1000） |
+| 版本 | Version 1.300（TL2026 实测；上游多年未更新，实际稳定） |
+| 覆盖 | 仅 **7,942/20,992（37.8%）** 基本区汉字（≈GB2312+），无 Ext-A/B。**古籍生僻字大量缺字** |
+| 授权 | OFL 1.1 |
+| 注意 | 曾因 CI 删 `ctex` 丢失其传递依赖 fandol 导致回归全挂（PR #107），装包列表现已显式声明 |
+
+### 0.3 macOS 本地开发字体（mac scheme）
+
+自动检测在 mac 上解析到系统字体（Songti SC / PingFang SC / Kaiti SC /
+STFangsong 等），随 macOS 版本漂移、**不可复现**，仅供本地预览。本机
+Songti SC 实测：version 17.0d2e3，仅 7,103 个基本区汉字（33.8%）——这
+就是 decorate/gongche/textbox 三个用例在 mac 上必然与基线有像素差异的
+根源（见 memory: regression-env-diff-tests）。
+
+### 0.4 文档/示例中出现过的第三方字体（不随项目分发）
+
+| 字体 | 授权 | 说明 |
+|------|------|------|
+| KingHwaOldSong 京華老宋体 | 作者自定义免费商用声明（**非 OFL**，约 39k 字含部分 Ext-B） | Issue #71 的 PUA 竖排补偿即为它引入 |
+| FZShuSong-Z01 方正书宋 | 商业授权（方正免费个人使用） | 仅示例提及 |
+| Noto Serif/Sans CJK | OFL 1.1 | autodetect 的 ubuntu/common 方案备选 |
+| 花園明朝 A/B | OFL 类（Hanazono 自由授权） | 文档提及，Ext-B 覆盖极好 |
+
+## 0.5 可复现性约定
+
+1. **Canonical 字体清单**：`scripts/font-manifest.json` 是机器可读的唯一
+   事实来源——每个字体的固定下载 URL（pinned commit）、SHA-256、版本、
+   授权、覆盖摘要都在这里。改字体 = 改 manifest，不改代码。
+2. **测试只认 TW-Kai**：回归 .tex 硬编码 `TW-Kai`，不依赖系统字体；
+   `regression_test.py` 自动把 `OSFONTDIR` 指向 `test/fonts/`。
+   **字体从不安装进用户系统字体库。**
+3. **下载即校验**：`python3 scripts/download_fonts.py`（或兼容入口
+   `sh scripts/download_test_fonts.sh`）按 manifest 下载并校验 SHA-256，
+   不符即报错；`--verify` 只校验、`--all` 连同 optional（Ext-B/Plus）。
+4. **CI 与本地同源**：CI 用同一脚本 + actions/cache（key 含脚本哈希）。
+5. **已知不可复现点**（按影响排序）：
+   - Fandol 经 CTAN 安装无版本锁（实际多年未变）；
+   - mac 系统字体随 OS 漂移（仅影响本地预览与 3 个已知用例的像素差异）；
+   - 若需彻底消除：让所有回归用例显式指定 TW-Kai 并重存基线（待议）。
+
+## 0.6 OFL / 开放来源替代方案评估（2026-07）
+
+结论：**TW-Kai 本身即可按 SIL OFL 1.1 使用**（官方双授权二选一），
+"换成 OFL 来源"不需要换字体，只需在文档与分发物中注明选用 OFL 1.1 并
+附授权文本。备选对比（楷体、面向古籍）：
+
+| 字体 | 授权 | 基本区 | Ext-A | Ext-B | 结论 |
+|------|------|--------|-------|-------|------|
+| **TW-Kai（现用）** | OFL 1.1（可选） | 99.7% | 100% | 100%（Ext-B 文件） | ✅ 保持现状最优 |
+| LXGW WenKai 霞鹜文楷 | OFL 1.1 | 通用规范 8,105 字为主 | 部分 | 无 | 风格佳但生僻字远不够 |
+| FandolKai | OFL 1.1 | 37.8% | 无 | 无 | 仅作 CI 缺省，不宜作基准 |
+| Noto Serif CJK | OFL 1.1 | 100% | 100% | 少量 | 宋体非楷体；Ext-B 弱 |
+| KingHwa 京華老宋体 | 自定义声明 | 高（约 39k 字） | 有 | 部分 | 非标准授权，且为宋体 |
+| 花園明朝 A+B | 自由授权 | 100% | 100% | 100% | 明朝体风格，日系笔形，不合楷书需求 |
+
+若未来需要 Ext-B 生僻字测试用例：引入 `TW-Kai-Ext-B-98_1.ttf`（下载
+脚本加一行即可，哈希见 0.1），fontspec 侧做 fallback 字体链。
+
+---
+
 # 字体 Metrics 特性总结
 
 > 不同字体在 LuaTeX 中的 metrics 表现差异，以及 luatex-cn 的应对策略。
@@ -156,3 +255,24 @@ comp_x = floor((0.5 - ratio_x) * glyph_width + 0.5)
 | PUA 码点还原 | `tex/core/luatex-cn-core-punct.lua` | L247-280 |
 | Y 轴补偿 | `tex/core/luatex-cn-core-punct.lua` | L844-856 |
 | 字体自动检测 | `tex/fonts/luatex-cn-font-autodetect.lua` | 全文 |
+
+## 8. 覆盖率复测方法（可复现）
+
+```bash
+# 依赖: pip install fonttools（或系统包）
+python3 - <<'EOF'
+from fontTools.ttLib import TTFont
+f = TTFont("test/fonts/TW-Kai-98_1.ttf", lazy=True)
+cmap = set(f.getBestCmap())
+for label, lo, hi in [("URO", 0x4E00, 0x9FFF), ("ExtA", 0x3400, 0x4DBF),
+                      ("ExtB", 0x20000, 0x2A6DF)]:
+    n = sum(1 for c in cmap if lo <= c <= hi)
+    print(label, f"{n}/{hi-lo+1}")
+EOF
+```
+
+数据来源链接：
+- 全字庫官方：https://data.gov.tw/dataset/5961 （双授权声明见页内）
+- 镜像仓库：https://github.com/free-fonts-npm/TW-CNS11643-Fonts （pinned commit 见下载脚本）
+- Fandol：https://ctan.org/pkg/fandol
+- LXGW WenKai：https://github.com/lxgw/LxgwWenKai

--- a/scripts/download_fonts.py
+++ b/scripts/download_fonts.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""按 scripts/font-manifest.json 下载项目字体到仓库内目录（不装系统字体）。
+
+用法:
+    python3 scripts/download_fonts.py            # 下载 required 字体（测试必需）
+    python3 scripts/download_fonts.py --all      # 连同 optional（Ext-B/Plus 等）
+    python3 scripts/download_fonts.py --verify   # 只校验已下载文件的 SHA-256
+
+字体放入 manifest 的 font_dir（默认 test/fonts/，gitignored），使用时通过
+OSFONTDIR 指向该目录（regression_test.py 已自动处理）。每个文件下载后校验
+SHA-256，与 manifest 不符即报错退出——保证任何环境拿到的字节完全一致。
+"""
+import argparse
+import hashlib
+import json
+import sys
+import urllib.request
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST = Path(__file__).resolve().parent / "font-manifest.json"
+
+
+def sha256_of(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def download(url, dest):
+    tmp = dest.with_suffix(dest.suffix + ".part")
+    print(f"下载: {url}")
+    with urllib.request.urlopen(url, timeout=120) as resp, open(tmp, "wb") as out:
+        while True:
+            chunk = resp.read(1 << 20)
+            if not chunk:
+                break
+            out.write(chunk)
+    tmp.rename(dest)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--all", action="store_true", help="包含 optional 字体")
+    ap.add_argument("--verify", action="store_true", help="只校验，不下载")
+    args = ap.parse_args()
+
+    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    font_dir = REPO_ROOT / manifest["font_dir"]
+    font_dir.mkdir(parents=True, exist_ok=True)
+
+    failures = []
+    for font in manifest["fonts"]:
+        optional = font.get("required_for") == ["optional"]
+        if optional and not (args.all or args.verify):
+            continue
+        dest = font_dir / font["file"]
+
+        if dest.exists():
+            actual = sha256_of(dest)
+            if actual == font["sha256"]:
+                print(f"已就绪: {font['file']} (sha256 OK)")
+                continue
+            if args.verify:
+                failures.append(f"{font['file']}: sha256 不符 {actual}")
+                continue
+            print(f"哈希不符，重新下载: {font['file']}")
+            dest.unlink()
+        elif args.verify:
+            if not optional:
+                failures.append(f"{font['file']}: 缺失")
+            continue
+
+        for url in font["urls"]:
+            try:
+                download(url, dest)
+                break
+            except Exception as e:  # noqa: BLE001 - 尝试下一个镜像
+                print(f"  失败 ({e})，尝试下一个源...", file=sys.stderr)
+        else:
+            failures.append(f"{font['file']}: 所有下载源均失败")
+            continue
+
+        actual = sha256_of(dest)
+        if actual != font["sha256"]:
+            dest.unlink()
+            failures.append(
+                f"{font['file']}: 下载内容 sha256 不符\n"
+                f"  期望 {font['sha256']}\n  实际 {actual}"
+            )
+        else:
+            print(f"完成: {font['file']} (sha256 OK)")
+
+    if failures:
+        print("\nERROR:", file=sys.stderr)
+        for f in failures:
+            print("  " + f, file=sys.stderr)
+        sys.exit(1)
+    print(f"\n字体位于 {font_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/download_test_fonts.sh
+++ b/scripts/download_test_fonts.sh
@@ -1,27 +1,6 @@
 #!/bin/sh
-# 下载回归测试所需的字体到 test/fonts/（该目录不入库）。
-# regression_test.py 会将 OSFONTDIR 指向 test/fonts，luaotfload 据此解析字体名。
-# 字体来源：全字庫 (CNS11643)，镜像仓库 free-fonts-npm/TW-CNS11643-Fonts，固定到 commit 以保证可复现。
+# 下载回归测试所需字体（兼容入口，实际逻辑在 download_fonts.py）。
+# 字体清单（canonical source of truth）: scripts/font-manifest.json
+# 字体进入 test/fonts/（gitignored），经 OSFONTDIR 使用，不装系统字体。
 set -eu
-
-REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
-FONTS_DIR="$REPO_ROOT/test/fonts"
-MIRROR="https://raw.githubusercontent.com/free-fonts-npm/TW-CNS11643-Fonts/de5bd2e37371798f996bac11ea8cf9d3a411749e/2026-05-05"
-
-mkdir -p "$FONTS_DIR"
-
-download() {
-    name=$1
-    url=$2
-    if [ -s "$FONTS_DIR/$name" ]; then
-        echo "已存在: $name"
-    else
-        echo "下载: $name"
-        curl -fL --retry 3 -o "$FONTS_DIR/$name.part" "$url"
-        mv "$FONTS_DIR/$name.part" "$FONTS_DIR/$name"
-    fi
-}
-
-download "TW-Kai-98_1.ttf" "$MIRROR/Fonts_Kai/TW-Kai-98_1.ttf"
-
-echo "完成。字体位于 $FONTS_DIR"
+exec python3 "$(dirname "$0")/download_fonts.py" "$@"

--- a/scripts/font-manifest.json
+++ b/scripts/font-manifest.json
@@ -1,0 +1,55 @@
+{
+  "manifest_version": 1,
+  "comment": "Canonical font manifest. Machine-consumable source of truth for every font the project downloads. Fonts go to font_dir (used via OSFONTDIR), never into the user's system font library. URLs must be immutable (pinned commit); sha256 is verified after download.",
+  "font_dir": "test/fonts",
+  "fonts": [
+    {
+      "name": "TW-Kai",
+      "file": "TW-Kai-98_1.ttf",
+      "family": "TW-Kai",
+      "font_version": "11503.01",
+      "format": "ttf",
+      "size": 36924208,
+      "sha256": "c206333edcc3c8c86ee547da4c78ad1c8f7ec2670a2b550a768532258f75806a",
+      "license": "OFL-1.1 OR OGDL-1.0",
+      "origin": "https://data.gov.tw/dataset/5961",
+      "urls": [
+        "https://raw.githubusercontent.com/free-fonts-npm/TW-CNS11643-Fonts/de5bd2e37371798f996bac11ea8cf9d3a411749e/2026-05-05/Fonts_Kai/TW-Kai-98_1.ttf"
+      ],
+      "coverage": "URO 99.7%, Ext-A 100%, CJK punct 100%; no Ext-B",
+      "required_for": ["regression-test"]
+    },
+    {
+      "name": "TW-Kai-Ext-B",
+      "file": "TW-Kai-Ext-B-98_1.ttf",
+      "family": "TW-Kai-Ext-B",
+      "font_version": "11505.01",
+      "format": "ttf",
+      "size": 46506552,
+      "sha256": "562d19fde56dfa52a3fed88a53154698e1d66e4b9c0a1faa9ba4ffa98e9d7a92",
+      "license": "OFL-1.1 OR OGDL-1.0",
+      "origin": "https://data.gov.tw/dataset/5961",
+      "urls": [
+        "https://raw.githubusercontent.com/free-fonts-npm/TW-CNS11643-Fonts/de5bd2e37371798f996bac11ea8cf9d3a411749e/2026-05-05/Fonts_Kai/TW-Kai-Ext-B-98_1.ttf"
+      ],
+      "coverage": "Ext-B 100%, Ext-C 98.6%, Ext-D 87.1%, Ext-E 21.9%",
+      "required_for": ["optional"]
+    },
+    {
+      "name": "TW-Kai-Plus",
+      "file": "TW-Kai-Plus-98_1.ttf",
+      "family": "TW-Kai-Plus",
+      "font_version": "11505.01",
+      "format": "ttf",
+      "size": 25307452,
+      "sha256": "acd099424c70c2baf3fe8d7b31abbbc6a97af76ef210e94c07eb1eb84d1c62fb",
+      "license": "OFL-1.1 OR OGDL-1.0",
+      "origin": "https://data.gov.tw/dataset/5961",
+      "urls": [
+        "https://raw.githubusercontent.com/free-fonts-npm/TW-CNS11643-Fonts/de5bd2e37371798f996bac11ea8cf9d3a411749e/2026-05-05/Fonts_Kai/TW-Kai-Plus-98_1.ttf"
+      ],
+      "coverage": "Plane-15 PUA 24,978 chars (CNS chars not yet in Unicode)",
+      "required_for": ["optional"]
+    }
+  ]
+}


### PR DESCRIPTION
## 动机

- 测试字体获取此前只有下载脚本里的硬编码 URL，字体信息（版本、授权、覆盖）散落各处
- 建立一个 **machine-consumable 的 canonical 字体清单**，使用仓库内目录 + OSFONTDIR，**不污染用户系统字体库**，并保证任何环境拿到的字节完全一致

## 改动

### 1. `scripts/font-manifest.json`（新增）
每个字体一条记录：固定 commit 的下载 URL、SHA-256、版本号、授权、覆盖摘要、用途标记。改字体 = 改 manifest，不改代码。当前收录 TW-Kai 全家族（主文件 + Ext-B + Plus，后两者标记 optional）。

### 2. `scripts/download_fonts.py`（新增）
- 按 manifest 下载到 `test/fonts/`（gitignored；经 OSFONTDIR 使用）
- 下载后校验 SHA-256，不符即报错；已有文件哈希不符自动重下
- `--verify` 只校验；`--all` 连同 optional 字体（古籍 Ext-B 生僻字场景）
- 每个字体支持多镜像 URL 顺序 fallback
- `download_test_fonts.sh` 改为薄封装，CI 与现有文档引用不变

### 3. `.claude/font-metrics.md`（扩充）
用 fontTools 实测数据补全字体清单：
- **TW-Kai**：Version 11503.01，URO 99.7% + Ext-A 100%；Ext-B 文件覆盖 Ext-B 100%/Ext-C 98.6%；Plus 文件收 24,978 个 Plane-15 PUA 字（Unicode 未收录的 CNS 字）
- **授权结论**：全字庫官方为双授权（政府開放資料授權 v1 **或 SIL OFL 1.1** 二选一），TW-Kai 已可按 OFL 使用，无需换字体；附 OFL 备选对比表（LXGW 文楷/Noto/京華/花園明朝，均因覆盖或风格不及）
- **Fandol**（CI 默认）：仅 7,942 个基本区字、无 Ext-A/B——古籍生僻字弱项已记录
- 可复现性约定与覆盖率复测方法
- 原有 metrics/PUA/居中经验全部保留

## 验证

- manifest 下载/校验/损坏自愈全链路本地测试通过
- unit test 30/30；回归测试链不受影响（字体文件与之前逐字节相同）