### PR TITLE
docs+ci: Wiki PDF 加构建戳，手动 workflow 以 PR 形式更新

### DIFF
--- a/.github/workflows/wiki-pdf.yml
+++ b/.github/workflows/wiki-pdf.yml
@@ -1,0 +1,78 @@
+name: Update Wiki PDFs
+
+on:
+  workflow_dispatch:       # 仅手动触发（Actions 页面点击运行）
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: wiki-pdf
+  cancel-in-progress: true
+
+jobs:
+  build-pdf:
+    # 只在 open-guji 主仓库运行
+    if: github.repository_owner == 'open-guji'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # stamp 的 repo_commit 需要完整历史做 diff 判断
+
+      - name: Clone wiki
+        run: git clone --depth 1 https://github.com/${{ github.repository }}.wiki.git wiki-src
+
+      - name: Check whether wiki changed since last build
+        id: check
+        run: |
+          wiki_head=$(git -C wiki-src rev-parse --short HEAD)
+          last_wiki=$(python3 -c "import json;print(json.load(open('文档/wiki-pdf-stamp.json'))['wiki_commit'])" 2>/dev/null || echo none)
+          last_repo=$(python3 -c "import json;print(json.load(open('文档/wiki-pdf-stamp.json'))['repo_commit'])" 2>/dev/null || echo none)
+          echo "wiki_head=$wiki_head" >> "$GITHUB_OUTPUT"
+          # wiki 与上次构建相同、且构建脚本自那以后无改动时跳过，
+          # 避免生成纯时间戳差异的噪音 PR
+          script_same=false
+          git diff --quiet "$last_repo" HEAD -- 文档/build_wiki_pdf.py 2>/dev/null && script_same=true
+          if [ "$wiki_head" = "$last_wiki" ] && [ "$script_same" = true ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Wiki and build script unchanged ($wiki_head), skipping build."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install dependencies
+        if: steps.check.outputs.changed == 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libpango-1.0-0 libpangocairo-1.0-0 fonts-noto-cjk
+          pip3 install --user markdown-it-py weasyprint
+
+      - name: Build PDFs
+        if: steps.check.outputs.changed == 'true'
+        run: LUATEX_CN_WIKI_DIR="$GITHUB_WORKSPACE/wiki-src" python3 文档/build_wiki_pdf.py
+
+      - name: Create pull request with updated PDFs
+        if: steps.check.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          branch="docs/wiki-pdf-${{ steps.check.outputs.wiki_head }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$branch"
+          git add 文档/luatex-cn-wiki-zh.pdf 文档/luatex-cn-wiki-en.pdf 文档/wiki-pdf-stamp.json
+          if git diff --cached --quiet; then
+            echo "No changes to commit."
+            exit 0
+          fi
+          git commit -m "docs: regenerate wiki PDFs (wiki @ ${{ steps.check.outputs.wiki_head }})"
+          git push -f origin "$branch"
+          # 已有同分支的开放 PR 时跳过创建（push 已更新其内容）
+          if [ -z "$(gh pr list --head "$branch" --state open --json number --jq '.[0].number')" ]; then
+            gh pr create \
+              --title "docs: 更新 Wiki PDF（wiki @ ${{ steps.check.outputs.wiki_head }}）" \
+              --body "由 wiki-pdf workflow 自动生成。wiki commit: \`${{ steps.check.outputs.wiki_head }}\`，构建信息见 \`文档/wiki-pdf-stamp.json\` 与 PDF 封面戳。"
+          fi

--- a/文档/build_wiki_pdf.py
+++ b/文档/build_wiki_pdf.py
@@ -11,8 +11,12 @@ Usage:
   python3 文档/build_wiki_pdf.py
 """
 
+import json
+import os
 import re
+import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 from markdown_it import MarkdownIt
@@ -22,8 +26,25 @@ from weasyprint import HTML
 # Configuration
 # ---------------------------------------------------------------------------
 
-WIKI_DIR = Path(__file__).resolve().parent.parent.parent / "luatex-cn.wiki"
+# Wiki checkout 位置：默认在仓库旁边，可用 LUATEX_CN_WIKI_DIR 覆盖（CI 用）
+WIKI_DIR = Path(
+    os.environ.get(
+        "LUATEX_CN_WIKI_DIR",
+        Path(__file__).resolve().parent.parent.parent / "luatex-cn.wiki",
+    )
+)
 OUT_DIR = Path(__file__).resolve().parent  # 文档/
+
+
+def git_head(repo_dir: Path) -> str:
+    """Return the short HEAD commit of a git checkout, or 'unknown'."""
+    try:
+        return subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=repo_dir, capture_output=True, text=True, check=True,
+        ).stdout.strip()
+    except (subprocess.CalledProcessError, OSError):
+        return "unknown"
 
 # Chapter ordering – mirrors _Sidebar.md structure
 ZH_CHAPTERS = [
@@ -124,6 +145,11 @@ def convert_wiki_links(md: str, valid_slugs: set[str]) -> str:
         if slug in valid_slugs:
             return f"[{display}](#{slug})"
         return display
+
+    # 表格单元格内的 wiki 链接会把竖线转义成 \|（[[A \| B]]），
+    # 先还原为普通分隔符，否则反斜杠残留在链接文本里产生 \]，
+    # 使 markdown 链接无法闭合、整段以字面文本渲染
+    md = re.sub(r"\[\[[^\]]+?\]\]", lambda m: m.group(0).replace("\\|", "|"), md)
 
     # [[display | target]] or [[target]]
     md = re.sub(r"\[\[([^|\]]+?)(?:\s*\|\s*([^\]]+?))?\]\]", _replace, md)
@@ -257,6 +283,12 @@ hr {
     color: #666;
 }
 
+.cover p.stamp {
+    font-size: 9pt;
+    color: #999;
+    margin-top: 40pt;
+}
+
 .toc {
     page-break-after: always;
 }
@@ -330,22 +362,35 @@ def build_toc_html(chapters: list[tuple[str, str]], is_zh: bool) -> str:
 """
 
 
+def build_stamp(is_zh: bool) -> str:
+    """Generation stamp: UTC timestamp + repo/wiki commits."""
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    repo_commit = git_head(Path(__file__).resolve().parent.parent)
+    wiki_commit = git_head(WIKI_DIR)
+    if is_zh:
+        return (f"生成时间 {ts} · 仓库 {repo_commit} · wiki {wiki_commit}")
+    return f"Generated {ts} · repo {repo_commit} · wiki {wiki_commit}"
+
+
 def build_cover_html(is_zh: bool) -> str:
     """Build cover page HTML."""
+    stamp = build_stamp(is_zh)
     if is_zh:
-        return """
+        return f"""
 <div class="cover">
 <h1>LuaTeX-CN 文档</h1>
 <p>— 高质量古籍排版宏包 —</p>
 <p>从 GitHub Wiki 自动生成</p>
+<p class="stamp">{stamp}</p>
 </div>
 """
     else:
-        return """
+        return f"""
 <div class="cover">
 <h1>LuaTeX-CN Documentation</h1>
 <p>— High-Quality Classical Chinese Typesetting —</p>
 <p>Auto-generated from GitHub Wiki</p>
+<p class="stamp">{stamp}</p>
 </div>
 """
 
@@ -419,6 +464,18 @@ def main():
 
     print("Building English PDF ...")
     build_pdf(EN_CHAPTERS, CSS_EN, OUT_DIR / "luatex-cn-wiki-en.pdf", is_zh=False)
+
+    # 生成 stamp：记录本次构建对应的 wiki/repo commit，
+    # CI workflow 据此判断 wiki 是否有更新、需不需要重建
+    stamp = {
+        "generated_utc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "repo_commit": git_head(Path(__file__).resolve().parent.parent),
+        "wiki_commit": git_head(WIKI_DIR),
+    }
+    stamp_path = OUT_DIR / "wiki-pdf-stamp.json"
+    stamp_path.write_text(
+        json.dumps(stamp, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    print("Stamp:", stamp)
 
     print("\nDone! PDFs are in:", OUT_DIR)
 


### PR DESCRIPTION
## 验证

`文档/build_wiki_pdf.py` 在本地实测可正常工作（weasyprint 69.0 + markdown-it-py），两份 PDF 均成功生成、封面戳与表格链接渲染正确。**本 PR 不包含重新生成的 PDF**——合并后手动触发 wiki-pdf workflow，由它以 PR 形式提交。

## 改动

### 1. 构建脚本 (`b7e87d1`)
- PDF 封面新增生成戳：**UTC 时间 + 仓库 commit + wiki commit**
- 同时写入 `文档/wiki-pdf-stamp.json`（machine-readable），记录本次构建对应的 wiki/repo 版本
- `WIKI_DIR` 支持 `LUATEX_CN_WIKI_DIR` 环境变量覆盖（CI 需要）
- **修复表格内 wiki 链接**：`[[A \| B]]` 的转义反斜杠漏进链接文本导致 markdown 链接无法闭合，Home 页「三个文档类」表格整段以字面文本渲染；现在转换前把 `[[...]]` 内的 `\|` 还原为 `|`

### 2. 更新 workflow (`2f33612`)
`.github/workflows/wiki-pdf.yml`，**仅 workflow_dispatch 手动触发**（无定时）：
- clone wiki → 若 wiki HEAD 与 stamp 一致**且**构建脚本无改动则跳过（stamp 不存在时必构建——首次触发即如此）
- 否则用 weasyprint + Noto CJK 重建两份 PDF，**以 commit + PR 的形式**提交（分支 `docs/wiki-pdf-<wiki-sha>`；同分支已有开放 PR 时仅更新内容不重复开）
- 只用 GITHUB_TOKEN + gh CLI，不引入第三方 PR Action；仅在 open-guji 主仓库运行

## 合并后使用方式

Actions → "Update Wiki PDFs" → Run workflow，构建结果会以新 PR 出现。