### PR TITLE
ci: wiki-pdf workflow 在无 PR 创建权限时降级为提示

### DIFF
--- a/.github/workflows/wiki-pdf.yml
+++ b/.github/workflows/wiki-pdf.yml
@@ -70,9 +70,13 @@ jobs:
           fi
           git commit -m "docs: regenerate wiki PDFs (wiki @ ${{ steps.check.outputs.wiki_head }})"
           git push -f origin "$branch"
-          # 已有同分支的开放 PR 时跳过创建（push 已更新其内容）
+          # 已有同分支的开放 PR 时跳过创建（push 已更新其内容）。
+          # 若仓库未开启 "Allow GitHub Actions to create and approve pull
+          # requests"，gh pr create 会被拒——此时输出手动创建链接，不算失败。
           if [ -z "$(gh pr list --head "$branch" --state open --json number --jq '.[0].number')" ]; then
-            gh pr create \
+            if ! gh pr create \
               --title "docs: 更新 Wiki PDF（wiki @ ${{ steps.check.outputs.wiki_head }}）" \
-              --body "由 wiki-pdf workflow 自动生成。wiki commit: \`${{ steps.check.outputs.wiki_head }}\`，构建信息见 \`文档/wiki-pdf-stamp.json\` 与 PDF 封面戳。"
+              --body "由 wiki-pdf workflow 自动生成。wiki commit: \`${{ steps.check.outputs.wiki_head }}\`，构建信息见 \`文档/wiki-pdf-stamp.json\` 与 PDF 封面戳。"; then
+              echo "::notice title=分支已推送，需手动创建 PR::https://github.com/${{ github.repository }}/pull/new/$branch （或在仓库 Settings → Actions → General 勾选 'Allow GitHub Actions to create and approve pull requests' 后重跑）"
+            fi
           fi


### PR DESCRIPTION
首次运行 wiki-pdf workflow 时，构建、commit、push 分支全部成功，但最后 `gh pr create` 因仓库未开启 **Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"** 被拒，整个 run 显示失败。

本 PR 改为：创建 PR 失败时输出 notice（含手动创建 PR 的链接和开启设置的指引），run 不再标红。

若希望以后全自动，也可以直接开启上述设置（等价 API：`gh api -X PUT repos/open-guji/luatex-cn/actions/permissions/workflow -f default_workflow_permissions=read -F can_approve_pull_request_reviews=true`），两者不冲突。