### PR TITLE
test: 为 6 个未指定字体的回归用例固定 FandolSong

### DIFF
--- a/test/regression_test/basic/tex/decorate.tex
+++ b/test/regression_test/basic/tex/decorate.tex
@@ -1,4 +1,5 @@
 \documentclass{ltc-guji}
+\setmainfont{FandolSong}
 \关闭分页
 
 \begin{document}

--- a/test/regression_test/basic/tex/gongche.tex
+++ b/test/regression_test/basic/tex/gongche.tex
@@ -1,4 +1,5 @@
 \documentclass{ltc-guji}
+\setmainfont{FandolSong}
 \关闭分页
 
 \begin{document}

--- a/test/regression_test/basic/tex/textbox.tex
+++ b/test/regression_test/basic/tex/textbox.tex
@@ -1,4 +1,5 @@
 \documentclass[四库全书]{ltc-guji}
+\setmainfont{FandolSong}
 \关闭分页
 
 \begin{document}

--- a/test/regression_test/complete/tex/example.tex
+++ b/test/regression_test/complete/tex/example.tex
@@ -1,5 +1,6 @@
 
 \documentclass[四库全书]{ltc-guji}
+\setmainfont{FandolSong}
 % 如果不指定字体，会使用系统默认中文字体
 % \setmainfont{Noto Serif SC}
 % \关闭分页

--- a/test/regression_test/past_issue/tex/newpage_after_space_issue63.tex
+++ b/test/regression_test/past_issue/tex/newpage_after_space_issue63.tex
@@ -1,6 +1,7 @@
 % newpage_after_space_issue63.tex - 回归测试: 空格挤字到行末后 newpage 内容丢失 (issue #63)
 % 问题: \空格[10] 将文字挤到列末，\newpage 后内容应正常排版
 \documentclass{ltc-guji}
+\setmainfont{FandolSong}
 \关闭分页
 
 \begin{document}

--- a/test/regression_test/past_issue/tex/space_issue62.tex
+++ b/test/regression_test/past_issue/tex/space_issue62.tex
@@ -1,5 +1,6 @@
 % space_issue62.tex - 回归测试: 连续空格继承 (issue #62)
 \documentclass{ltc-guji}
+\setmainfont{FandolSong}
 
 \begin{document}
 \begin{正文}


### PR DESCRIPTION
## 问题

6 个回归用例未显式指定字体，走平台自动检测：本机 mac 选 Songti SC、CI 的 ubuntu 选 Fandol，导致这些用例在本机必然与基线超差（长期被当作"可忽略的环境差异"），而基线一旦在本机重存，CI 又会反向失败（#113 曾踩中）。

涉及用例：
- basic：`decorate.tex`、`gongche.tex`、`textbox.tex`
- past_issue：`newpage_after_space_issue63.tex`、`space_issue62.tex`
- complete：`example.tex`（原 `\setmainfont` 被注释掉了）

## 修复

每个文件加一行 `\setmainfont{FandolSong}`（TeX Live 自带、CI 已装 fandol 包）。**共 6 行改动，零基线改动。**

## 发现

加声明后本机渲染与现有基线**逐字节相同**——这些基线当初就是 Fandol 渲染生成的，历史失败纯粹是自动检测在 mac 上选了 Songti。附带证明 FandolSong 跨 mac/Linux 渲染逐字节可复现，适合作为无风格要求用例的默认测试字体。

## 验证

- unit test 30/30
- 三套件全量回归通过；仅剩 3 个既有缺字体编译失败（kinsoku/font/shiji16，均为字体专项用例，与本 PR 无关）

## 后续

本 PR 合并后，#113 将 rebase 到其上并丢弃其分支里的字体提交（被本 PR 取代），再重存受 em 框修复影响的基线——从此基线在两端环境均可复现。