### PR TITLE
fix: 水落津门排版修复（grid-height=0 覆盖 + 空左小列状态污染）

### DIFF
--- a/tex/core/luatex-cn-core-textflow.lua
+++ b/tex/core/luatex-cn-core-textflow.lua
@@ -572,7 +572,10 @@ local function place_textflow_segment(ctx, nodes, layout_map, params, callbacks,
             local sid = D.get_attribute(n, constants.ATTR_STYLE_REG_ID)
             if sid and sid > 0 then
                 local sgh = style_registry.get_grid_height(sid)
-                if sgh and sgh > 0 and sgh ~= gh then
+                -- sgh == 0 is a valid override: zero-advance overlay glyph
+                -- (e.g. the compressed closing bracket of a jiao note that
+                -- shares its cell with the following character)
+                if sgh and sgh >= 0 and sgh ~= gh then
                     if not node_heights then
                         node_heights = {}
                         for j = 1, i - 1 do node_heights[j] = gh end
@@ -690,7 +693,7 @@ local function place_textflow_segment(ctx, nodes, layout_map, params, callbacks,
                 local sid = D.get_attribute(node_info.node, constants.ATTR_STYLE_REG_ID)
                 if sid and sid > 0 then
                     local style_ch = style_registry.get_grid_height(sid)
-                    if style_ch and style_ch > 0 then
+                    if style_ch and style_ch >= 0 then
                         node_cell_h = style_ch
                     end
                 end

--- a/tex/digital/luatex-cn-digital.sty
+++ b/tex/digital/luatex-cn-digital.sty
@@ -112,8 +112,13 @@
       {
         \tl_if_empty:NF \l__luatexcn_digital_right_col_tl
           {
-            % Empty left column: call TextFlow with empty content to consume pending state
-            \TextFlow[only-column=left, auto-balance=false]{ }
+            % Empty left column: an empty TextFlow emits NO nodes, so the
+            % layout pass never sees the left-only call and pending_sub_col=1
+            % survives, corrupting the next \DualColumn (content overprints
+            % the previous column). Typeset one U+3000 (invisible full-width
+            % space glyph) so a real mode-2 node reaches the layout and
+            % consumes the pending state.
+            \TextFlow[only-column=left, auto-balance=false]{　}
           }
       }
       {

--- a/tex/digital/luatex-cn-digital.sty
+++ b/tex/digital/luatex-cn-digital.sty
@@ -99,15 +99,7 @@
           { \exp_args:NV \__luatexcn_set_indent:n \l__luatexcn_digital_right_indent_tl }
         \TextFlow[only-column=right, auto-balance=false]{ \l__luatexcn_digital_right_col_tl }
       }
-    % When left sub-column is empty but right was non-empty, insert a
-    % full-width space as placeholder. This ensures the left-only TextFlow
-    % produces a glyph node that consumes the pending_sub_col=1 state
-    % from the right TextFlow, preventing state corruption for subsequent
-    % \DualColumn calls.
     % Output left sub-column (even if empty)
-    % When left is empty and right was non-empty, the empty TextFlow call
-    % will trigger the pending_sub_col cleanup logic in textflow.lua:434-438,
-    % which properly advances cur_row without generating any glyph nodes.
     \tl_if_empty:NTF \l__luatexcn_digital_left_col_tl
       {
         \tl_if_empty:NF \l__luatexcn_digital_right_col_tl


### PR DESCRIPTION
## 概述

排录《水落津门》(00167) 时发现的两个排版 bug 修复。

## 修复内容

### 1. `fix(textflow)`: 尊重 grid-height=0 的样式覆盖 (85dc659)

`place_textflow_segment` 中 `node_heights` 构建和逐节点 `cell_height` 解析都要求 `sgh > 0`，导致显式的 `grid-height=0pt` 覆盖被静默丢弃。零步进是合法值：叠印字形与后续字符共享格位（如校注的旋转闭括号，原书将其塞在注文末字下方、不占格）。覆盖被忽略时，括号在夹注 textflow 中占满一格，把该列末字挤出（00167 叶55：「六」被换列，原书能放下）。两处均放宽为 `sgh >= 0`；`nil` 仍回退到全局 grid height。

- 未设置 grid-height 的样式经 TeX 层传 `nil`（`luatex-cn-core-style.sty:71`），不会误伤普通样式。

### 2. `fix(digital)`: 空左小列必须产出真实节点 (cc79aea)

`\双列` 的 `\左小列` 为空时，原代码用空内容调用 `\TextFlow[only-column=left]{ }`——不产生任何字形节点，layout 阶段根本看不到这次 left-only 调用，right-only 调用留下的 `textflow_pending_sub_col=1` 存活并污染下一个 `\双列`：其右小列内容叠印到前一列上、后续列错位（00167 p130：「以上各條…」叠印在「限滿出所…」上）。改为排一个 U+3000（不可见全角空格字形），让一个真实的 mode-2 节点到达 layout 消费掉 pending 状态。

另附一个注释清理提交，删除 digital.sty 中描述两版旧方案的过时注释。

## 测试

- ✅ `texlua test/run_all.lua` — 30/30 通过
- ✅ `python3 test/regression_test.py check --all` — basic / past_issue / complete 三套件全部通过
- ✅ `python3 test/geometry_test.py` — 通过