### PR TITLE
fix(test): run_all.lua 失败漏报 — LuaTeX os.execute 返回状态数字而非布尔

### DIFF
--- a/test/run_all.lua
+++ b/test/run_all.lua
@@ -61,9 +61,10 @@ for _, test_file in ipairs(tests) do
     print("------------------------------------------------------------")
     local ok, reason, code = os.execute("texlua " .. test_file)
 
-    -- In Lua 5.3+ (LuaTeX), os.execute returns (success, reason, code)
-    -- success is true/nil
-    if ok then
+    -- LuaTeX 的 os.execute 不遵循 Lua 5.3 约定（true/nil, reason, code），
+    -- 而是返回原始状态数字（0=成功，如 256=exit 1）。数字永远为真值，
+    -- 只判 if ok 会把失败文件统计为通过。两种形态都须兼容。
+    if ok == true or ok == 0 then
         passed = passed + 1
     else
         print("\n[!] FAILURE in " ..


### PR DESCRIPTION
## 问题

`test/run_all.lua` 用 `if ok then` 判定 `os.execute` 的返回值，注释假定 Lua 5.3 约定（`true/nil, reason, code`）。但 LuaTeX/texlua 的 `os.execute` 实际返回 C `system()` 的**原始状态数字**（成功=0，exit 1=256）。数字永远为真值，因此**任何单元测试文件失败都会被统计为通过**，本地与 CI 的单元测试环节一直是空转绿灯。

## 复现

```
$ texlua -e 探测: os.execute("exit 1") → number 256（真值）
向 tests 列表注入必败文件 → 仍报 ALL TESTS PASSED, Failed: 0
```

## 修复

兼容两种返回形态：`if ok == true or ok == 0`。

## 验证

- 注入必败文件：正确报 `Failed: 1`、列出失败文件、以非零码退出
- 本分支单独运行 `texlua test/run_all.lua`：30/30 真实通过（已用 stash 隔离工作区其他改动验证）

已同步记录到 LEARNING.md 3.8（随后续字体功能 PR 提交）。