### PR TITLE
feat(fonts): 下载脚本支持 --user/--dest 安装免安装字体，新增 npm woff2 切片源

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,11 @@ texlua test/unit_test/core/layout-grid-test.lua
 # 首次运行前：下载测试字体 TW-Kai 到 test/fonts/（不入库，不装系统字体）
 sh scripts/download_test_fonts.sh
 
+# 使用者日常排版的免安装字体（同一 manifest/脚本）：
+#   --user 装入 TEXMFHOME/fonts/truetype/luatex-cn/；--dest DIR 放入文档项目目录
+#   文档中 \setmainfont{TW-Kai-98_1.ttf} 或 \setmainfont{X.ttf}[Path=./fonts/] 直接引用
+python3 scripts/download_fonts.py --all --user
+
 # 运行所有测试
 python3 test/regression_test.py check
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 本项目的所有重大更改都将记录在此文件中。
 
+## [未发布]
+
+新增：
+- scripts/download_fonts.py 新增 --user（安装到 TEXMFHOME/fonts/truetype/luatex-cn/，免管理员权限、不进系统字体库）与 --dest DIR（放入文档项目目录），下载后可用 \setmainfont{文件名.ttf} 直接引用
+- 字体下载支持 npm woff2 切片源 — 下载 tarball 后用 fonttools 合并为单个 TTF（vert/vrt2 竖排特性保留），首个条目为朱雀仿宋 @free-fonts/zhuque-fangsong
+
+修复：
+- test/run_all.lua 失败漏报 — LuaTeX 的 os.execute 返回原始状态数字而非布尔值，此前任何单元测试失败都会被统计为通过 (#121)
+
 ## [0.3.8] - 2026-05-09
 
 新增：

--- a/scripts/download_fonts.py
+++ b/scripts/download_fonts.py
@@ -3,16 +3,24 @@
 
 用法:
     python3 scripts/download_fonts.py            # 下载 required 字体（测试必需）
-    python3 scripts/download_fonts.py --all      # 连同 optional（Ext-B/Plus 等）
+    python3 scripts/download_fonts.py --all      # 连同 optional（Ext-B/Plus/朱雀等）
     python3 scripts/download_fonts.py --verify   # 只校验已下载文件的 SHA-256
+    python3 scripts/download_fonts.py --user     # 安装到 TEXMFHOME（供日常排版使用）
+    python3 scripts/download_fonts.py --dest DIR # 下载到指定目录（如文档项目的 ./fonts/）
 
-字体放入 manifest 的 font_dir（默认 test/fonts/，gitignored），使用时通过
-OSFONTDIR 指向该目录（regression_test.py 已自动处理）。每个文件下载后校验
-SHA-256，与 manifest 不符即报错退出——保证任何环境拿到的字节完全一致。
+字体默认放入 manifest 的 font_dir（test/fonts/，gitignored），供测试经 OSFONTDIR
+使用。日常排版用 --user 装入 TEXMFHOME/fonts/truetype/luatex-cn/（免管理员权限、
+不进系统字体库，luaotfload 可按文件名找到），或用 --dest 放进文档目录后以
+\\设置字体族{Jigmo} / \\setmainfont{Jigmo.ttf} 引用。
+
+普通条目下载后校验 SHA-256，与 manifest 不符即报错退出。带 npm 源的条目
+（woff2 切片）会下载 tarball（校验其 sha256）后用 fonttools 合并为单个 TTF，
+合并输出不校验哈希（fonttools 版本可能影响字节），需要 pip install fonttools brotli。
 """
 import argparse
 import hashlib
 import json
+import subprocess
 import sys
 import urllib.request
 from pathlib import Path
@@ -45,16 +53,8 @@ def extract_from_archive(archive, member, dest, font_dir):
     """从 zip 压缩包中解出字体文件。压缩包按 sha256 缓存复用。"""
     import zipfile
 
-    cache_dir = font_dir / ".archives"
-    cache_dir.mkdir(parents=True, exist_ok=True)
-    cached = cache_dir / (archive["sha256"][:16] + ".zip")
-    if not (cached.exists() and sha256_of(cached) == archive["sha256"]):
-        download(archive["url"], cached)
-        actual = sha256_of(cached)
-        if actual != archive["sha256"]:
-            cached.unlink()
-            raise RuntimeError(
-                f"压缩包 sha256 不符: 期望 {archive['sha256']} 实际 {actual}")
+    cached = fetch_archive(archive["url"], archive["sha256"],
+                           font_dir / ".archives", ".zip")
     with zipfile.ZipFile(cached) as zf:
         with zf.open(archive.get("member", member)) as src, open(dest, "wb") as out:
             while True:
@@ -64,14 +64,90 @@ def extract_from_archive(archive, member, dest, font_dir):
                 out.write(chunk)
 
 
+def fetch_archive(url, sha256, cache_dir, suffix):
+    """下载压缩包到缓存目录（按 sha256 命名复用），校验后返回路径。"""
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    cached = cache_dir / (sha256[:16] + suffix)
+    if not (cached.exists() and sha256_of(cached) == sha256):
+        download(url, cached)
+        actual = sha256_of(cached)
+        if actual != sha256:
+            cached.unlink()
+            raise RuntimeError(f"压缩包 sha256 不符: 期望 {sha256} 实际 {actual}")
+    return cached
+
+
+def build_from_npm_woff2(npm, dest, font_dir):
+    """npm woff2 切片一条龙：下载 tarball → 解出切片 → 合并为单个 TTF。
+
+    切片是按 Unicode 区段拆分的同一字体的子集（webfont 分发形态），字形集互不
+    重叠，可用 fontTools.merge 无损合回；实测 GSUB 的 vert/vrt2 竖排特性保留。
+    """
+    import fnmatch
+    import os
+    import tarfile
+    import tempfile
+
+    try:
+        from fontTools.ttLib import TTFont
+        from fontTools.merge import Merger
+    except ImportError:
+        raise RuntimeError(
+            "npm woff2 字体需要 fonttools 与 brotli，请先: pip install fonttools brotli")
+
+    tarball = fetch_archive(npm["tarball"], npm["sha256"],
+                            font_dir / ".archives", ".tgz")
+    # SOURCE_DATE_EPOCH 固定 head 表时间戳，使同版本 fonttools 的输出可复现
+    os.environ.setdefault("SOURCE_DATE_EPOCH", "0")
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        slices = []
+        with tarfile.open(tarball, "r:gz") as tf:
+            for member in tf.getmembers():
+                if fnmatch.fnmatch(member.name, npm["member_glob"]):
+                    tf.extract(member, tmp, filter="data")
+                    slices.append(tmp / member.name)
+        if not slices:
+            raise RuntimeError(f"tarball 中未找到 {npm['member_glob']}")
+        print(f"合并 {len(slices)} 片 woff2 → {dest.name} ...")
+        ttfs = []
+        for i, w in enumerate(sorted(slices)):
+            f = TTFont(w)
+            f.flavor = None  # woff2 → 普通 sfnt
+            out = tmp / f"slice{i:04d}.ttf"
+            f.save(out)
+            ttfs.append(str(out))
+        merged = Merger().merge(ttfs)
+        merged.save(dest)
+
+
+def resolve_texmfhome():
+    out = subprocess.run(["kpsewhich", "-var-value", "TEXMFHOME"],
+                         capture_output=True, text=True, check=True)
+    home = out.stdout.strip()
+    if not home:
+        raise RuntimeError("kpsewhich 未返回 TEXMFHOME")
+    return Path(home).expanduser()
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--all", action="store_true", help="包含 optional 字体")
     ap.add_argument("--verify", action="store_true", help="只校验，不下载")
+    dest_group = ap.add_mutually_exclusive_group()
+    dest_group.add_argument("--dest", metavar="DIR",
+                            help="下载到指定目录（如文档项目的 ./fonts/）")
+    dest_group.add_argument("--user", action="store_true",
+                            help="安装到 TEXMFHOME/fonts/truetype/luatex-cn/（日常排版用）")
     args = ap.parse_args()
 
     manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
-    font_dir = REPO_ROOT / manifest["font_dir"]
+    if args.user:
+        font_dir = resolve_texmfhome() / "fonts" / "truetype" / "luatex-cn"
+    elif args.dest:
+        font_dir = Path(args.dest).expanduser().resolve()
+    else:
+        font_dir = REPO_ROOT / manifest["font_dir"]
     font_dir.mkdir(parents=True, exist_ok=True)
 
     failures = []
@@ -80,10 +156,14 @@ def main():
         if optional and not (args.all or args.verify):
             continue
         dest = font_dir / font["file"]
+        expected_sha = font.get("sha256")  # npm 合并输出无固定哈希，条目可不含此字段
 
         if dest.exists():
+            if expected_sha is None:
+                print(f"已就绪: {font['file']} (npm 合并输出，不校验哈希)")
+                continue
             actual = sha256_of(dest)
-            if actual == font["sha256"]:
+            if actual == expected_sha:
                 print(f"已就绪: {font['file']} (sha256 OK)")
                 continue
             if args.verify:
@@ -96,8 +176,16 @@ def main():
                 failures.append(f"{font['file']}: 缺失")
             continue
 
+        npm = font.get("npm")
         archive = font.get("archive")
-        if archive:
+        if npm:
+            # npm woff2 切片：下载 tarball（校验 sha256）→ fonttools 合并为 TTF
+            try:
+                build_from_npm_woff2(npm, dest, font_dir)
+            except Exception as e:  # noqa: BLE001
+                failures.append(f"{font['file']}: npm 构建失败 ({e})")
+                continue
+        elif archive:
             # zip 分发的字体：下载（或复用）压缩包，校验后解出成员文件。
             # 压缩包按其 sha256 缓存在 font_dir/.archives/，同包多字体只下一次。
             try:
@@ -117,11 +205,13 @@ def main():
                 continue
 
         actual = sha256_of(dest)
-        if actual != font["sha256"]:
+        if expected_sha is None:
+            print(f"完成: {font['file']} (sha256 {actual[:16]}…，npm 合并输出不校验)")
+        elif actual != expected_sha:
             dest.unlink()
             failures.append(
                 f"{font['file']}: 下载内容 sha256 不符\n"
-                f"  期望 {font['sha256']}\n  实际 {actual}"
+                f"  期望 {expected_sha}\n  实际 {actual}"
             )
         else:
             print(f"完成: {font['file']} (sha256 OK)")
@@ -132,6 +222,9 @@ def main():
             print("  " + f, file=sys.stderr)
         sys.exit(1)
     print(f"\n字体位于 {font_dir}")
+    if args.user:
+        print("已安装到 TEXMFHOME，\\设置字体族 / \\setmainfont{文件名.ttf} 可直接使用；"
+              "如需按字体名引用，请再执行: luaotfload-tool --update")
 
 
 if __name__ == "__main__":

--- a/scripts/font-manifest.json
+++ b/scripts/font-manifest.json
@@ -1,6 +1,6 @@
 {
-  "manifest_version": 1,
-  "comment": "Canonical font manifest. Machine-consumable source of truth for every font the project downloads. Fonts go to font_dir (used via OSFONTDIR), never into the user's system font library. URLs must be immutable (pinned commit); sha256 is verified after download.",
+  "manifest_version": 2,
+  "comment": "Canonical font manifest. Machine-consumable source of truth for every font the project downloads. Fonts go to font_dir (used via OSFONTDIR), never into the user's system font library. URLs must be immutable (pinned commit); sha256 is verified after download. Entries with an npm source are built by merging unicode-range woff2 slices into one TTF (requires fonttools+brotli); only the tarball sha256 is pinned because the merged bytes may vary across fonttools versions.",
   "font_dir": "test/fonts",
   "fonts": [
     {
@@ -118,6 +118,28 @@
         "regression-test"
       ],
       "comment": "complete/font.tex 字体族回退链第 3 层"
+    },
+    {
+      "name": "ZhuqueFangsong",
+      "file": "ZhuqueFangsong.ttf",
+      "family": "Zhuque Fangsong (technical preview)",
+      "font_version": "0.212",
+      "format": "ttf",
+      "license": "OFL-1.1",
+      "origin": "https://github.com/TrionesType/zhuque",
+      "npm": {
+        "package": "@free-fonts/zhuque-fangsong",
+        "version": "1.0.0",
+        "tarball": "https://registry.npmjs.org/@free-fonts/zhuque-fangsong/-/zhuque-fangsong-1.0.0.tgz",
+        "sha256": "ac45c3a2613e9c3fdddf85bb00a88d92d9e877872cb8f82c98ba777d83b96848",
+        "member_glob": "package/fonts/*.woff2"
+      },
+      "urls": [],
+      "coverage": "12,882 cmap 字符（含 vert/vrt2 竖排特性，合并后保留）",
+      "required_for": [
+        "optional"
+      ],
+      "comment": "npm woff2 切片（187 片）下载后合并为单个 TTF；无 sha256 字段=只校验 tarball"
     }
   ]
 }


### PR DESCRIPTION
## 目的

让使用者日常排版也能方便获取并使用未装进系统的字体（此前 manifest+下载脚本只服务测试环境的 OSFONTDIR 方案）。

## 新增

### 统一下载目标
- `--user`：安装到 `TEXMFHOME/fonts/truetype/luatex-cn/` — 免管理员权限、不进系统字体库，kpse 可按文件名直接找到，文档中 `\setmainfont{TW-Kai-98_1.ttf}` 即可引用（按字体名引用需再跑 `luaotfload-tool --update`，脚本会提示）
- `--dest DIR`：下载到文档项目目录，配合 `\setmainfont{X.ttf}[Path=./fonts/]` 或同目录裸文件名使用，文档可自包含分发
- 默认行为不变（test/fonts + OSFONTDIR，测试/CI 不受影响）

### npm woff2 切片源（下载→转换一条龙）
- manifest 新增 `npm` 源类型：下载 tarball（锁定 sha256）→ 解出按 Unicode 区段切片的 woff2 → fonttools 合并为单个 TTF
- 切片是同一字体的互斥子集，可无损合并；实测 GSUB `vert`/`vrt2` 竖排特性完整保留
- 需要 `pip install fonttools brotli`，缺库时给出友好提示；合并输出不校验哈希（fonttools 版本影响字节），只锁 tarball；设 `SOURCE_DATE_EPOCH=0` 保证同版本可复现
- 首个条目：朱雀仿宋 `@free-fonts/zhuque-fangsong`（187 片 → 13,605 字形，LuaTeX 编译零缺字验证通过）

### 其他
- CHANGELOG 补记 #121 run_all.lua 修复条目

## 验证

- `--dest` 到临时目录全量下载（含 npm 构建）✅
- `--user` 安装 TEXMFHOME 后，无 OSFONTDIR、无本地 fonts/ 目录的文档经 kpse 正常加载 ✅
- `--verify` 对无 sha256 的 npm 条目按存在性校验 ✅
- 单元测试 30/30、`--verify` 通过（stash 隔离验证纯净分支）

## 后续

PR 2 将基于本 PR 为 `\设置字体族` 增加注册表别名（{Jigmo} 自动展开）与文件路径解析——缺字错误提示会引用本 PR 的 `--user`/`--dest` 选项，故本 PR 先行。