### PR TITLE
feat(fonts): \设置字体族 支持注册表别名与免安装字体文件解析

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,8 @@ sh scripts/download_test_fonts.sh
 
 # 使用者日常排版的免安装字体（同一 manifest/脚本）：
 #   --user 装入 TEXMFHOME/fonts/truetype/luatex-cn/；--dest DIR 放入文档项目目录
-#   文档中 \setmainfont{TW-Kai-98_1.ttf} 或 \setmainfont{X.ttf}[Path=./fonts/] 直接引用
+#   文档中 \设置字体族{Jigmo}（注册表别名）、\设置字体族{fonts/MyFont.ttf}（文件路径）
+#   或 \setmainfont{TW-Kai-98_1.ttf} 直接引用
 python3 scripts/download_fonts.py --all --user
 
 # 运行所有测试

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [未发布]
 
 新增：
+- 免安装字体支持 — \设置字体族 接受注册表别名（如 {Jigmo} 自动展开为 Jigmo+Jigmo2）、字体文件名与路径（{fonts/MyFont.ttf}），系统已装则用系统的，否则按 ./fonts/ → 文档目录 → kpse（TEXMFHOME/OSFONTDIR）查找本地文件，均未找到时报错并提示下载脚本用法
 - scripts/download_fonts.py 新增 --user（安装到 TEXMFHOME/fonts/truetype/luatex-cn/，免管理员权限、不进系统字体库）与 --dest DIR（放入文档项目目录），下载后可用 \setmainfont{文件名.ttf} 直接引用
 - 字体下载支持 npm woff2 切片源 — 下载 tarball 后用 fonttools 合并为单个 TTF（vert/vrt2 竖排特性保留），首个条目为朱雀仿宋 @free-fonts/zhuque-fangsong
 

--- a/ai_must_read/LEARNING.md
+++ b/ai_must_read/LEARNING.md
@@ -356,6 +356,59 @@ y = y - (cell_height + p.ascender + p.descender) / 2 + p.descender
 **适用场景**：任何按格定位字形的代码（主文本 `calc_grid_position`、
 侧批 sidenote、版心 `position_glyph`），三处已统一用 `get_em_span()`。
 
+### 3.7 luaotfload 字体请求语法：file: 带路径必挂，路径要用方括号
+
+**问题**：给 `luaotfload.add_fallback` 传文件路径条目时，字体加载失败
+（"Font \"file\" not found" 或 fallback 模块索引 nil 崩溃）。
+
+**根本原因**：luaotfload 请求解析器的 `file:` 前缀只接受**裸文件名**
+（经 kpse 在 cwd/TEXMF/OSFONTDIR 查找）；带 `/` 的相对或绝对路径都会解析失败。
+
+**错误方案**：
+```lua
+-- ❌ file: 带路径（相对/绝对都不行）
+luaotfload.add_fallback(id, { "file:fonts/Jigmo2.ttf:mode=node;" })
+luaotfload.add_fallback(id, { "file:/abs/path/Jigmo2.ttf:mode=node;" })
+```
+
+**正确方案**：
+```lua
+-- ✅ 路径用方括号语法；裸文件名才可用 file:
+luaotfload.add_fallback(id, { "[/abs/path/Jigmo2.ttf]:mode=node;" })
+luaotfload.add_fallback(id, { "file:Jigmo2.ttf:mode=node;" })
+```
+
+**关键点**：
+- fontspec 侧等价形式是 `\setmainfont{Jigmo2.ttf}[Path=./fonts/]`，无需安装系统字体
+- 检查字体名是否已在索引：用 `luaotfload.aux.resolve_fontname(name)`（查不到返回
+  false，不触发重扫）；早年的 `luaotfload.find_file` **已不存在**，写
+  `if lotf.find_file then ... end` 兜底"无法检查就当存在"会把没装的字体误判为已装
+
+**适用场景**：`\设置字体族` / `prepare_family` 的免安装字体解析（见
+`tex/fonts/luatex-cn-font-autodetect.lua`）。
+
+### 3.8 LuaTeX 的 os.execute 返回状态数字，不是布尔
+
+**问题**：`test/run_all.lua` 多年来把失败的测试文件统计为通过——注入必败
+文件后仍报 "ALL TESTS PASSED"。
+
+**根本原因**：LuaTeX/texlua 的 `os.execute` 不遵循 Lua 5.3 约定
+（`true/nil, "exit", code`），而是返回 C `system()` 的**原始状态数字**
+（成功=0，exit 1=256）。数字永远为真值，`if ok then` 恒成立。
+
+**正确方案**：
+```lua
+-- ✅ 两种返回形态都要兼容
+local ok = os.execute(cmd)
+if ok == true or ok == 0 then --[[ 成功 ]] end
+```
+
+**关键点**：
+- 验证方法：`os.execute("exit 1")` 在 texlua 下返回 `number 256`
+- 依赖子进程退出码的任何 texlua 脚本都要按此判定
+
+**适用场景**：texlua 编写的测试 runner、批处理脚本。
+
 ---
 
 ## 四、 PDF 渲染问题

--- a/scripts/font-manifest.json
+++ b/scripts/font-manifest.json
@@ -1,7 +1,10 @@
 {
   "manifest_version": 2,
-  "comment": "Canonical font manifest. Machine-consumable source of truth for every font the project downloads. Fonts go to font_dir (used via OSFONTDIR), never into the user's system font library. URLs must be immutable (pinned commit); sha256 is verified after download. Entries with an npm source are built by merging unicode-range woff2 slices into one TTF (requires fonttools+brotli); only the tarball sha256 is pinned because the merged bytes may vary across fonttools versions.",
+  "comment": "Canonical font manifest. Machine-consumable source of truth for every font the project downloads. Fonts go to font_dir (used via OSFONTDIR), never into the user's system font library. URLs must be immutable (pinned commit); sha256 is verified after download. Entries with an npm source are built by merging unicode-range woff2 slices into one TTF (requires fonttools+brotli); only the tarball sha256 is pinned because the merged bytes may vary across fonttools versions. aliases group multiple member fonts under one family name for \\设置字体族 (must mirror fontdetect.registry in tex/fonts/luatex-cn-font-autodetect.lua).",
   "font_dir": "test/fonts",
+  "aliases": {
+    "Jigmo": ["Jigmo.ttf", "Jigmo2.ttf"]
+  },
   "fonts": [
     {
       "name": "TW-Kai",

--- a/test/unit_test/fonts/luatex-cn-font-autodetect-test.lua
+++ b/test/unit_test/fonts/luatex-cn-font-autodetect-test.lua
@@ -149,4 +149,128 @@ test_utils.run_test("add_family_fallback: single font registers nothing", functi
     luaotfload.add_fallback = org
 end)
 
+-- ============================================================================
+-- registry / find_font_file / prepare_family（字体族别名与免安装字体解析）
+-- ============================================================================
+
+test_utils.run_test("registry: consistent with font-manifest.json aliases", function()
+    local f = assert(io.open("scripts/font-manifest.json", "rb"))
+    local manifest = f:read("*a")
+    f:close()
+    local block = manifest:match('"aliases"%s*:%s*(%b{})')
+    test_utils.assert_type(block, "string", "manifest missing aliases block")
+
+    local manifest_files = 0
+    for _ in block:gmatch('%.tt[fc]"') do manifest_files = manifest_files + 1 end
+    local registry_files = 0
+    for alias, def in pairs(fontdetect.registry) do
+        assert(block:find('"' .. alias .. '"', 1, true),
+            "manifest aliases 缺少别名 " .. alias)
+        for _, m in ipairs(def.members) do
+            registry_files = registry_files + 1
+            assert(block:find('"' .. m.file .. '"', 1, true),
+                "manifest aliases 缺少文件 " .. m.file)
+        end
+    end
+    test_utils.assert_eq(manifest_files, registry_files,
+        "manifest 与 registry 的成员文件数不一致")
+end)
+
+test_utils.run_test("find_font_file: checks ./fonts/ then ./", function()
+    local org = fontdetect._internal.file_exists
+    fontdetect._internal.file_exists = function(p) return p == "./fonts/Jigmo2.ttf" end
+    test_utils.assert_eq(fontdetect.find_font_file("Jigmo2.ttf"), "./fonts/Jigmo2.ttf")
+
+    fontdetect._internal.file_exists = function(p) return p == "./Jigmo2.ttf" end
+    test_utils.assert_eq(fontdetect.find_font_file("Jigmo2.ttf"), "./Jigmo2.ttf")
+
+    fontdetect._internal.file_exists = function() return false end
+    test_utils.assert_eq(fontdetect.find_font_file("Jigmo2.ttf"), nil)
+    fontdetect._internal.file_exists = org
+end)
+
+local function with_family_mocks(opts, body)
+    -- 统一装拆 prepare_family 依赖的 mock，返回捕获的 macros / fallback entries
+    local org_name_lookup = fontdetect._internal.name_lookup
+    local org_exists = fontdetect._internal.file_exists
+    _G.luaotfload = _G.luaotfload or {}
+    local org_fb = luaotfload.add_fallback
+    local org_set_macro = token.set_macro
+    local captured = { macros = {}, fb = nil }
+    fontdetect._internal.name_lookup = opts.name_lookup or function() return false end
+    fontdetect._internal.file_exists = opts.file_exists or function() return false end
+    luaotfload.add_fallback = function(id, entries)
+        captured.fb = { id = id, entries = entries }
+    end
+    token.set_macro = function(name, value) captured.macros[name] = value end
+
+    local ok, err = pcall(body, captured)
+
+    fontdetect._internal.name_lookup = org_name_lookup
+    fontdetect._internal.file_exists = org_exists
+    luaotfload.add_fallback = org_fb
+    token.set_macro = org_set_macro
+    if not ok then error(err, 0) end
+end
+
+test_utils.run_test("prepare_family: alias mixes system name and local file", function()
+    with_family_mocks({
+        name_lookup = function(n) return n == "Jigmo" end,
+        file_exists = function(p) return p == "./fonts/Jigmo2.ttf" end,
+    }, function(captured)
+        local resolved = fontdetect.prepare_family("famchain", "Jigmo")
+        test_utils.assert_eq(#resolved, 2)
+        test_utils.assert_eq(resolved[1].kind, "name")
+        test_utils.assert_eq(resolved[1].value, "Jigmo")
+        test_utils.assert_eq(resolved[2].kind, "path")
+        test_utils.assert_eq(resolved[2].value, "./fonts/Jigmo2.ttf")
+        -- 路径条目必须用 [路径] 方括号语法（file: 带路径会解析失败）
+        test_utils.assert_eq(captured.fb.entries[1], "[./fonts/Jigmo2.ttf]:mode=node;")
+        test_utils.assert_eq(captured.macros.l__luatexcn_family_main_tl, "Jigmo")
+        test_utils.assert_eq(captured.macros.l__luatexcn_family_dir_tl, "")
+        test_utils.assert_eq(captured.macros.l__luatexcn_family_fallback_tl, "famchain")
+    end)
+end)
+
+test_utils.run_test("prepare_family: alias member missing raises with download hint", function()
+    with_family_mocks({}, function()
+        local ok, err = pcall(fontdetect.prepare_family, "famchain", "Jigmo")
+        test_utils.assert_eq(ok, false)
+        test_utils.assert_match(tostring(err), "download_fonts%.py")
+        test_utils.assert_match(tostring(err), "Jigmo2%.ttf")
+    end)
+end)
+
+test_utils.run_test("prepare_family: file main gets Path dir, name fallback", function()
+    with_family_mocks({
+        file_exists = function(p) return p == "fonts/My.ttf" end,
+    }, function(captured)
+        local resolved = fontdetect.prepare_family("famchain", "fonts/My.ttf, TW-Kai")
+        test_utils.assert_eq(#resolved, 2)
+        test_utils.assert_eq(captured.macros.l__luatexcn_family_main_tl, "My.ttf")
+        test_utils.assert_eq(captured.macros.l__luatexcn_family_dir_tl, "fonts/")
+        test_utils.assert_eq(captured.fb.entries[1], "name:TW-Kai:mode=node;")
+    end)
+end)
+
+test_utils.run_test("prepare_family: single name registers no fallback", function()
+    with_family_mocks({}, function(captured)
+        local resolved = fontdetect.prepare_family("famchain", "FandolSong")
+        test_utils.assert_eq(#resolved, 1)
+        test_utils.assert_eq(captured.fb, nil)
+        test_utils.assert_eq(captured.macros.l__luatexcn_family_main_tl, "FandolSong")
+        test_utils.assert_eq(captured.macros.l__luatexcn_family_fallback_tl, "")
+    end)
+end)
+
+test_utils.run_test("prepare_family: bare filename resolved via find_font_file", function()
+    with_family_mocks({
+        file_exists = function(p) return p == "./fonts/Jigmo2.ttf" end,
+    }, function(captured)
+        local resolved = fontdetect.prepare_family("famchain", "TW-Kai, Jigmo2.ttf")
+        test_utils.assert_eq(resolved[2].kind, "path")
+        test_utils.assert_eq(captured.fb.entries[1], "[./fonts/Jigmo2.ttf]:mode=node;")
+    end)
+end)
+
 print("\nAll font-autodetect tests passed!")

--- a/tex/fonts/luatex-cn-font-autodetect.lua
+++ b/tex/fonts/luatex-cn-font-autodetect.lua
@@ -262,6 +262,195 @@ function fontdetect.get_font_setup()
     }
 end
 
+-- ============================================================================
+-- 字体族别名注册表与免安装字体解析
+-- ============================================================================
+-- 别名 → 成员列表。names 供系统/luaotfload 名字查找，file 供本地文件查找。
+-- 成员文件名须与 scripts/font-manifest.json 的 aliases 一致（unit test 校验）。
+fontdetect.registry = {
+    Jigmo = {
+        members = {
+            { names = { "Jigmo" },  file = "Jigmo.ttf" },
+            { names = { "Jigmo2" }, file = "Jigmo2.ttf" },
+        },
+    },
+}
+
+fontdetect._internal = fontdetect._internal or {}
+
+function fontdetect._internal.file_exists(path)
+    local f = io.open(path, "rb")
+    if f then f:close() return true end
+    return false
+end
+
+--- 严格的字体名查找：查 luaotfload 名字索引。
+-- @return true/false 可判定结果；nil 表示当前环境无法判定
+-- 注意 luaotfload.find_file 是早年 API，现行版本已无此函数；
+-- 现行稳定入口是 luaotfload.aux.resolve_fontname（查不到返回 false，不触发重扫）。
+function fontdetect._internal.name_lookup(fontname)
+    if not fontname or fontname == "" then return false end
+    local lotf = _G.luaotfload
+    if lotf and lotf.aux and type(lotf.aux.resolve_fontname) == "function" then
+        return lotf.aux.resolve_fontname(fontname) and true or false
+    end
+    if lotf and type(lotf.find_file) == "function" then
+        return lotf.find_file(fontname) ~= nil
+    end
+    return nil
+end
+
+--- 从别名列表中找系统已装字体；无法判定时视为未装（宁走文件回退，不盲报有）
+local function find_installed_font(names)
+    for _, n in ipairs(names) do
+        if fontdetect._internal.name_lookup(n) then return n end
+    end
+    return nil
+end
+
+--- 在免安装位置查找字体文件：文档目录 ./fonts/、文档目录本身、
+-- 以及 kpse（覆盖 TEXMFHOME/fonts/truetype/luatex-cn/ 与 OSFONTDIR）。
+-- @param filename (string) 字体文件名，如 "Jigmo2.ttf"
+-- @return (string|nil) 可用路径
+function fontdetect.find_font_file(filename)
+    for _, dir in ipairs({ "./fonts/", "./" }) do
+        local p = dir .. filename
+        if fontdetect._internal.file_exists(p) then return p end
+    end
+    if kpse and kpse.find_file then
+        -- pcall：texlua 环境下 kpse 需先 set_program_name，直接调用会抛错
+        local ok, found = pcall(function()
+            return kpse.find_file(filename, "truetype fonts")
+                or kpse.find_file(filename, "opentype fonts")
+        end)
+        if ok then return found end
+    end
+    return nil
+end
+
+local function trim(s)
+    return (s:gsub("^%s+", ""):gsub("%s+$", ""))
+end
+
+local function is_font_filename(s)
+    local lower = s:lower()
+    return lower:match("%.ttf$") or lower:match("%.otf$") or lower:match("%.ttc$")
+end
+
+--- 生成一条 luaotfload fallback 链条目。
+-- 名字用 name: 前缀；文件路径必须用 [路径] 方括号语法——
+-- file: 前缀带路径（相对或绝对）会解析失败，只有裸文件名可用。
+local function fallback_entry(kind, value)
+    if kind == "path" then
+        return "[" .. value .. "]:mode=node;"
+    end
+    return "name:" .. value .. ":mode=node;"
+end
+
+--- 解析单个字体规格：带 .ttf/.otf/.ttc 后缀按文件处理，否则按名字。
+-- @return kind ("name"|"path"|nil), value
+local function resolve_spec(spec)
+    if is_font_filename(spec) then
+        if spec:match("[/\\]") then
+            if fontdetect._internal.file_exists(spec) then return "path", spec end
+            return nil
+        end
+        local p = fontdetect.find_font_file(spec)
+        if p then return "path", p end
+        return nil
+    end
+    -- 名字规格不预检存在性：luaotfload 索引可能滞后，交给 fontspec 处理更友好
+    return "name", spec
+end
+
+local function report_missing(family, missing)
+    local msg = string.format(
+        '[luatex-cn] 字体族 "%s" 缺少字体文件: %s\n'
+        .. "获取方式（任选其一）:\n"
+        .. "  1. python3 scripts/download_fonts.py --all --user   (安装到 TEXMFHOME)\n"
+        .. "  2. python3 scripts/download_fonts.py --all --dest ./fonts   (放入文档目录)\n"
+        .. "  3. 手动下载后放入文档目录 ./fonts/ 或 TEXMFHOME/fonts/truetype/luatex-cn/",
+        family, table.concat(missing, ", "))
+    if tex and tex.error then
+        tex.error(msg)
+    else
+        error(msg)
+    end
+end
+
+--- \设置字体族 的统一入口：解析字体族并注册回退链。
+-- namelist 为单个注册表别名（如 "Jigmo"）时展开为成员列表，逐成员解析：
+-- 系统装了就按名字用系统的，否则找本地文件，都没有则报错并提示下载脚本。
+-- 普通逗号列表按原样解析，其中带字体后缀的条目按文件查找。
+-- 解析结果经 token.set_macro 回填三个 tl 供 .sty 侧调用 \setmainfont：
+--   l__luatexcn_family_main_tl     主字体名或文件名
+--   l__luatexcn_family_dir_tl      主字体所在目录（fontspec Path=，名字方式为空）
+--   l__luatexcn_family_fallback_tl 回退链 id（无回退时为空）
+-- @return (table) 解析结果 {kind=..., value=...} 列表（供测试断言）
+function fontdetect.prepare_family(id, namelist)
+    namelist = trim(namelist)
+    local resolved, missing = {}, {}
+    local alias = fontdetect.registry[namelist]
+    if alias then
+        for _, m in ipairs(alias.members) do
+            local name = find_installed_font(m.names)
+            if name then
+                table.insert(resolved, { kind = "name", value = name })
+            else
+                local p = fontdetect.find_font_file(m.file)
+                if p then
+                    table.insert(resolved, { kind = "path", value = p })
+                else
+                    table.insert(missing, m.file)
+                end
+            end
+        end
+    else
+        for spec in string.gmatch(namelist, "[^,]+") do
+            spec = trim(spec)
+            if spec ~= "" then
+                local kind, value = resolve_spec(spec)
+                if kind then
+                    table.insert(resolved, { kind = kind, value = value })
+                else
+                    table.insert(missing, spec)
+                end
+            end
+        end
+    end
+
+    if #missing > 0 then
+        report_missing(namelist, missing)
+    end
+    if #resolved == 0 then return resolved end
+
+    local main = resolved[1]
+    local main_name, main_dir = main.value, ""
+    if main.kind == "path" then
+        main_dir, main_name = main.value:match("^(.*[/\\])([^/\\]+)$")
+        if not main_name then
+            main_dir, main_name = "./", main.value
+        end
+    end
+
+    local entries = {}
+    for i = 2, #resolved do
+        table.insert(entries, fallback_entry(resolved[i].kind, resolved[i].value))
+    end
+    local fallback_id = ""
+    if #entries > 0 and luaotfload and luaotfload.add_fallback then
+        luaotfload.add_fallback(id, entries)
+        fallback_id = id
+    end
+
+    if token and token.set_macro then
+        token.set_macro("l__luatexcn_family_main_tl", main_name)
+        token.set_macro("l__luatexcn_family_dir_tl", main_dir)
+        token.set_macro("l__luatexcn_family_fallback_tl", fallback_id)
+    end
+    return resolved
+end
+
 --- 注册字体族回退链（\设置字体族 / \setfontfamily 的多字体支持）
 -- 把列表第 2..n 项注册为 luaotfload fallback，使首字体缺字时逐级回退。
 -- @param id (string) fallback 链的唯一名称

--- a/tex/fonts/luatex-cn-font-autodetect.sty
+++ b/tex/fonts/luatex-cn-font-autodetect.sty
@@ -169,26 +169,46 @@
 % Usage: \SetMainFontChain{Font1, Font2, Font3}
 % 字体族：首字体为主字体，其余各项注册为 luaotfload fallback 链，
 % 首字体缺字时按顺序回退（如 {FandolSong, TW-Kai, TW-Kai-Ext-B}）。
+%
+% 三种规格均可混用，字体无需安装进系统：
+%   \设置字体族{Jigmo}                    -- 注册表别名，自动展开为 Jigmo+Jigmo2，
+%                                            系统有则用系统的，否则找本地文件
+%   \设置字体族{TW-Kai, Jigmo2.ttf}       -- 名字与文件名混搭
+%   \设置字体族{fonts/MyFont.ttf}         -- 带路径的字体文件
+% 文件查找顺序：./fonts/ → ./ → kpse（TEXMFHOME、OSFONTDIR）。
+% 找不到时报错并提示 scripts/download_fonts.py 的用法。
 \int_new:N \g__luatexcn_fontfamily_int
+\tl_new:N \l__luatexcn_family_main_tl
+\tl_new:N \l__luatexcn_family_dir_tl
+\tl_new:N \l__luatexcn_family_fallback_tl
 \DeclareDocumentCommand{\setfontfamily}{m}
   {
-    \tl_set:Nx \l_tmpa_tl { \clist_item:nn { #1 } { 1 } }
-    \int_compare:nNnTF { \clist_count:n { #1 } } > { 1 }
+    \int_gincr:N \g__luatexcn_fontfamily_int
+    \tl_set:Nx \l_tmpb_tl { luatexcnfamfb \int_use:N \g__luatexcn_fontfamily_int }
+    % 先清空，防止解析全部失败时沿用上次调用的残留值
+    \tl_clear:N \l__luatexcn_family_main_tl
+    \tl_clear:N \l__luatexcn_family_dir_tl
+    \tl_clear:N \l__luatexcn_family_fallback_tl
+    % prepare_family 解析别名/名字/文件，注册回退链，
+    % 并经 token.set_macro 回填 main/dir/fallback 三个 tl
+    \lua_now:e
       {
-        \int_gincr:N \g__luatexcn_fontfamily_int
-        \tl_set:Nx \l_tmpb_tl { luatexcnfamfb \int_use:N \g__luatexcn_fontfamily_int }
-        \lua_now:e
-          {
-            fontdetect.add_family_fallback("\l_tmpb_tl","\clist_use:nn { #1 } { , }")
-          }
-        % \use:x 预展开字体名与链名，规避 xparse 可选参数不展开变量的限制
+        fontdetect.prepare_family("\l_tmpb_tl","\clist_use:nn { #1 } { , }")
+      }
+    \tl_if_empty:NF \l__luatexcn_family_main_tl
+      {
+        % \use:x 预展开字体名与选项，规避 xparse 可选参数不展开变量的限制
         \use:x
           {
-            \exp_not:N \setmainfont { \l_tmpa_tl }
-              [ RawFeature = { fallback = \l_tmpb_tl } ]
+            \exp_not:N \setmainfont { \l__luatexcn_family_main_tl }
+              [
+                \tl_if_empty:NF \l__luatexcn_family_dir_tl
+                  { Path = \l__luatexcn_family_dir_tl , }
+                \tl_if_empty:NF \l__luatexcn_family_fallback_tl
+                  { RawFeature = { fallback = \l__luatexcn_family_fallback_tl } }
+              ]
           }
       }
-      { \exp_args:NV \setmainfont \l_tmpa_tl }
   }
 
 \DeclareDocumentCommand{\setFontFamily}{m}{\setfontfamily{#1}}


### PR DESCRIPTION
基于 #122（需先合并，本 PR 的错误提示引用其 `--user`/`--dest` 选项——已合并✅）。

## 功能

`\设置字体族` 现在接受三种规格，可混用，字体无需装进系统字体库：

```latex
\设置字体族{Jigmo}                  % 注册表别名 → 自动展开为 Jigmo+Jigmo2 回退链
\设置字体族{fonts/MyFont.ttf, TW-Kai}  % 文件路径与名字混搭
\设置字体族{Source Han Serif SC, SimSun}  % 原有名字用法不变
```

## 解析机制（fontdetect.prepare_family）

逐成员三级解析：**系统已装（按名字）→ 本地文件（./fonts/ → 文档目录 → kpse 覆盖 TEXMFHOME/OSFONTDIR）→ 报错**，错误信息原样给出 `download_fonts.py --user` / `--dest ./fonts` 命令与手动放置路径。系统与本地文件可逐成员混搭（如系统有 Jigmo、本地只有 Jigmo2）。

关键实现点（已记入 LEARNING.md 3.7）：
- 回退链文件条目必须用 `[路径]` 方括号语法——`file:` 前缀带路径会解析失败
- 系统名检查用 `luaotfload.aux.resolve_fontname`（严格查索引）；早年的 `luaotfload.find_file` 已不存在，旧的"无法检查就当存在"兜底会把没装的字体误判为已装
- manifest 新增 `aliases` 字段，与 `fontdetect.registry` 的一致性由单元测试强制约束（首批只加不常见的 Jigmo）

## 验证

- 新增 7 个单元测试（mock `name_lookup`/`file_exists`/`add_fallback`/`set_macro`），全量 30/30 通过
- 回归测试 20/20 通过（含使用 `\设置字体族` 名字规格的 complete/font.tex，行为不变）
- 端到端（无 OSFONTDIR）：字体放 `./fonts/` 与 `--user` 装 TEXMFHOME 两种方式均正常编译，Ext-B 字形经回退链渲染无缺字；缺文件时报错信息符合预期
- LEARNING.md 新增 3.7（luaotfload 请求语法）与 3.8（os.execute 状态数字，对应 #121）