### PR TITLE
fix(ctan): 打包修补——垃圾清理与 docs/ 子目录拷贝（打 tag 前需合并）

### DIFF
--- a/build.lua
+++ b/build.lua
@@ -513,12 +513,36 @@ local function ctan_custom()
   for _, doc in ipairs(docfiles) do
     if path_exists(doc) then
       print("  Copying: " .. doc)
-      copy_path(doc, join_path(staging_path, doc))
+      local dest = join_path(staging_path, doc)
+      -- 目标含子目录（如 docs/CLREQ-CONFORMANCE.md）时先建父目录，
+      -- 否则 cp 静默失败、文件缺包
+      local parent = dest:match("^(.*)[/\\][^/\\]+$")
+      if parent and not is_dir(parent) then
+        if sep == "\\" then
+          os.execute('mkdir "' .. parent .. '" 2>nul')
+        else
+          os.execute('mkdir -p "' .. parent .. '"')
+        end
+      end
+      copy_path(doc, dest)
     end
   end
 
   -- Step 6: Post-process (copy tex folder, Chinese folders, translate names)
   post_process_ctan(staging_path)
+
+  -- Step 6.5: Prune junk files picked up from the working tree
+  -- (.DS_Store/__pycache__ 等只存在于本地目录，CI 干净 checkout 没有，
+  --  但本地打包会被 cp -r 整目录带入)
+  print("\n>>> Pruning junk files...")
+  if sep == "\\" then
+    os.execute('for /d /r "' .. staging_path .. '" %d in (__pycache__) do @if exist "%d" rd /s /q "%d"')
+    os.execute('del /s /q "' .. staging_path .. '\\.DS_Store" 2>nul')
+    os.execute('del /s /q "' .. staging_path .. '\\Thumbs.db" 2>nul')
+  else
+    os.execute('find "' .. staging_path .. '" \\( -name __pycache__ -type d \\) -prune -exec rm -rf {} + 2>/dev/null')
+    os.execute('find "' .. staging_path .. '" \\( -name .DS_Store -o -name Thumbs.db -o -name "*.pyc" \\) -delete 2>/dev/null')
+  end
 
   -- Step 7: Create final zip
   print("\n>>> Creating CTAN archive...")


### PR DESCRIPTION
本地按 CTAN 上传标准验证 v0.4.0 发布包时发现两个打包问题，需在打 tag 前合并：

1. **本地垃圾入包**：`cp -r` 整目录会把 `.DS_Store`、`__pycache__/*.pyc` 带进 zip。CI 的干净 checkout 侥幸没有，但本地打的包与 CI 应当一致。staging 后统一清除（macOS/Linux 用 find，Windows 用 rd/del）。
2. **`docs/CLREQ-CONFORMANCE.md` 一直缺包**：docfiles 里有它，但拷贝目标的父目录 `staging/docs/` 不存在，`cp` 静默失败。先建父目录再拷。

### 验证
- `l3build ctan` 产包 199 文件；垃圾文件 0；CONFORMANCE 入包
- 解包后 `TEXINPUTS` 指向包内 `tex/` 独立冒烟编译：竖排（`ltc-guji` + 句读 + 夹注）与横排（`luatex-cn` + taiwan）均一次通过、无错误；`kpsewhich` 确认类文件解析自包内而非本机 texmf